### PR TITLE
[ #26 | Chore ] 버셀 무료 배포를 위한 github action 설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
+
+      - name: creates output
+        run: sh ./build.sh
+
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }}
+        with:
+          source-directory: 'output'
+          destination-github-username: youjin-hong
+          destination-repository-name: client
+          user-email: ${{ secrets.EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: main
+
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd ../
+mkdir output
+cp -R ./client/* ./output
+cp -R ./output ./client


### PR DESCRIPTION
## 🛰️ Issue Number
이슈번호: #26

## 🪐 작업 내용
organization의 repo를 배포하려면 pro 플랜밖에 이용을 못한다고 해서 무료로 배포하는 방법을 찾아서 시도해보았습니다. 
- 현재 client 레포 내 래포로 fork
- vercel에 fork한 내 레포지토리의 프로젝트 deploy
- secret key 발급
- 우리 프로젝트 root에 build.sh 파일 작성
- 우리 프로젝트 root/github 폴더에 workflow 폴더 생성 후, deply.yml 작성


## 📚 Reference
[[Github Action] 깃허브 Organization 레포지토리 vercel 자동 배포]](https://jjang-j.tistory.com/93)
[vercel에 팀 프로젝트 배포하기](https://vanilla-van-6e4.notion.site/vercel-47312c7c2a9c492dbdabc40c47489cfa)
[GitHub Organization 프로젝트를 vercel 무료로 연동하기 (+git actions)](https://velog.io/@rmaomina/organization-vercel-hobby-deploy)
[github-action-push-to-another-repository 문서](https://cpina.github.io/push-to-another-repository-docs/)

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] 코드 스타일을 eslint/prettier로 맞췄나요?