### PR TITLE
[ #28 | Fix ] 백엔드 배포 도메인 추가, 이미지 경로 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ next-env.d.ts
 # Cache
 .eslintcache
 .cache
+
+.env

--- a/src/components/layout/page-layout/Header.tsx
+++ b/src/components/layout/page-layout/Header.tsx
@@ -1,4 +1,7 @@
 import { useUserProfile } from '@/store/queries/user/useUserQueries';
+import searchIcon from '@/assets/icons/search.svg';
+import notificationIcon from '@/assets/icons/notification.svg';
+import profileImg from '@/assets/images/짱구.jpg';
 
 export default function Header() {
   const { data: profile } = useUserProfile();
@@ -13,7 +16,7 @@ export default function Header() {
       {/* 검색창 */}
       <div className="relative flex max-w-[510px] max-h-[50px] w-full bg-white py-3 px-5 mx-2 rounded-[23.5px]">
         <button type="button">
-          <img src="/src/assets/icons/search.svg" alt="search button" className="absolute left-5 top-2" />
+          <img src={searchIcon} alt="search button" className="absolute left-5 top-2" />
         </button>
         <input type="text" placeholder="프로젝트 검색" className="w-full rounded-[23.5px] pl-10" />
       </div>
@@ -22,14 +25,14 @@ export default function Header() {
         {/* 알림 버튼 */}
         <div className="flex items-center">
           <button>
-            <img src="/src/assets/icons/notification.svg" alt="notification button" />
+            <img src={notificationIcon} alt="notification button" />
           </button>
         </div>
 
         {/* 프로필 버튼 */}
         <button className="flex max-w-44 gap-2 rounded-15 px-5 py-1 bg-white">
           <div className="w-9 h-9 rounded-full bg-gray-300 flex items-center justify-center overflow-hidden">
-            <img src="/src/assets/images/짱구.jpg" alt="profile img" className="w-full h-full object-cover" />
+            <img src={profileImg} alt="profile img" className="w-full h-full object-cover" />
           </div>
           <div className="flex flex-col justify-center items-start">
             <p className="font-bm text-14">{profile?.username}</p>

--- a/src/components/layout/sidebar/Sidebar.tsx
+++ b/src/components/layout/sidebar/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { Link, useNavigate } from 'react-router-dom';
+import smallLogo from '@/assets/logos/AUTA_small.svg';
 import { ROUTES } from '@/constants';
 import { useLogout } from '@/store/queries/auth/useAuthMutations';
 import MenuItem from '@/components/layout/sidebar/_components/MenuItem';
@@ -23,7 +24,7 @@ export default function Sidebar() {
   return (
     <aside className="fixed left-0 top-0 max-w-[280px] w-full h-screen z-[999] bg-[#E9E9E9]">
       <Link to="/" className="flex justify-center pt-8 pb-14">
-        <img src="/src/assets/logos/AUTA_small.svg" alt="logo" />
+        <img src={smallLogo} alt="logo" />
       </Link>
 
       <div className="my-4">

--- a/src/pages/auth/_components/AuthForm.tsx
+++ b/src/pages/auth/_components/AuthForm.tsx
@@ -1,3 +1,4 @@
+import bigLogo from '@/assets/logos/AUTA_big.svg';
 import Button from '@/components/ui/button/Button';
 import Input from '@/components/ui/input/Input';
 import { ROUTES } from '@/constants';
@@ -43,7 +44,7 @@ export default function AuthForm({ type, onSubmit }: AuthFormProps) {
   return (
     <div className="flex flex-col items-center">
       <Link to={ROUTES.LANDING}>
-        <img src="/src/assets/logos/AUTA_big.svg" alt="AUTA big logo" className="py-20" />
+        <img src={bigLogo} alt="AUTA big logo" className="py-20" />
       </Link>
       <form onSubmit={handleSubmitAuthForm} className="flex flex-col gap-8 max-w-[446px] w-full">
         <Input label="이메일" type="email" value={email} onChange={(e) => setEmail(e.target.value)} />

--- a/src/pages/setting/ProfileEditPage.tsx
+++ b/src/pages/setting/ProfileEditPage.tsx
@@ -1,3 +1,5 @@
+import settingIcon from '@/assets/icons/setting.svg';
+import profileImg from '@/assets/images/짱구.jpg';
 import { User } from '@/types/user.type';
 import ProfileForm from '@/pages/setting/_components/ProfileForm';
 import { useUserProfile } from '@/store/queries/user/useUserQueries';
@@ -33,7 +35,7 @@ export default function ProfileEditPage() {
       <section className="flex flex-col gap-5 pl-6">
         <div className="flex items-center gap-3 pl-6 pb-3">
           <div>
-            <img src="/src/assets/icons/setting.svg" alt="setting icon" />
+            <img src={settingIcon} alt="setting icon" />
           </div>
           <p className="font-bm text-20">설정</p>
         </div>
@@ -42,7 +44,7 @@ export default function ProfileEditPage() {
       <section className="flex w-full gap-10">
         <div className="flex flex-col items-center gap-6">
           <div className="w-72 h-72 rounded-full overflow-hidden">
-            <img src="/src/assets/images/짱구.jpg" alt="profileImg" className="w-full h-full object-cover" />
+            <img src={profileImg} alt="profileImg" className="w-full h-full object-cover" />
           </div>
           <p className="font-bm text-32 text-typography-dark">{profile.username}</p>
           <p className="font-medium text-14 text-typography-dark">Test Automation Developer</p>

--- a/src/pages/setting/SettingPage.tsx
+++ b/src/pages/setting/SettingPage.tsx
@@ -1,3 +1,4 @@
+import settingIcon from '@/assets/icons/setting.svg';
 import { useNavigate } from 'react-router-dom';
 import SettingCard from '@/pages/setting/_components/SettingCard';
 import { SettingCardProps, settingItem } from '@/pages/setting/_components/SettingCardData';
@@ -16,7 +17,7 @@ export default function SettingPage() {
   return (
     <div className="space-y-8 w-[90%]">
       <div className="flex items-center gap-3 pl-12">
-        <img src="/src/assets/icons/setting.svg" alt="setting icon" />
+        <img src={settingIcon} alt="setting icon" />
         <p className="font-bm text-20">설정</p>
       </div>
       <div className="space-y-10 pl-6 pt-2">

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -26,6 +26,7 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"],
+      "@/assets/*": ["src/assets/*"]
     }
   },
   "include": ["./src/**/*.ts", "./src/**/*.tsx"]


### PR DESCRIPTION
## 🛰️ Issue Number
이슈번호: #28

## 🪐 작업 내용
- 루트 디렉토리에 `.env`파일 추가해서 백엔드 도메인 추가
- 상대경로로 `<img>` 태그에 쓰인 경로 import문으로 변경


<커밋 설명>
- .env 파일 생성 후, `VITE_API_BASE_URL=https://kwauta.duckdns.org/api/v1` 추가해주세요
- mui 설치했으니 pull 하면 npm install 해주세요


## 📚 Reference


## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
- [ ] 코드 스타일을 eslint/prettier로 맞췄나요?