### PR TITLE
[ #22 | Feat ] 프로젝트 생성 페이지 개발

### DIFF
--- a/src/components/layout/page-layout/Header.tsx
+++ b/src/components/layout/page-layout/Header.tsx
@@ -2,14 +2,28 @@ import { useUserProfile } from '@/store/queries/user/useUserQueries';
 import searchIcon from '@/assets/icons/search.svg';
 import notificationIcon from '@/assets/icons/notification.svg';
 import profileImg from '@/assets/images/짱구.jpg';
+import { useLocation } from 'react-router-dom';
+import { useMemo } from 'react';
+import { menuItems, topMenuItem } from '@/components/layout/sidebar/_components/SidebarData';
 
 export default function Header() {
   const { data: profile } = useUserProfile();
+  const location = useLocation();
+
+  // 현재 경로에 있는 사이드 바의 메뉴 아이템 찾기
+  const currentPage = useMemo(() => {
+    const allMenuItems = [...menuItems, topMenuItem];
+    const matchedItem = allMenuItems.find(
+      (item) => item.path === location.pathname || (location.pathname.startsWith(item.path) && item.path !== '/')
+    );
+
+    return matchedItem ? matchedItem.title : '';
+  }, [location.pathname]);
 
   return (
     <header className="sticky top-0 z-[999] w-full bg-background flex items-center justify-around py-10">
       {/* 현재 페이지 이름 */}
-      <h1 className="font-bm font-medium text-32 cursor-default">현재페이지이름</h1>
+      <h1 className="font-bm font-medium text-32 cursor-default">{currentPage}</h1>
 
       {/* 검색창 */}
       <div className="relative flex max-w-[510px] max-h-[50px] w-full bg-white py-3 px-5 mx-2 rounded-[23.5px]">

--- a/src/components/ui/input/Input.tsx
+++ b/src/components/ui/input/Input.tsx
@@ -5,6 +5,7 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   name?: string;
   required?: boolean;
   className?: string;
+  labelClassName?: string;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
   onEnterPress?: () => void;
 }
@@ -14,6 +15,7 @@ export default function Input({
   name,
   value,
   className = '',
+  labelClassName = '',
   required = false,
   onChange,
   onEnterPress,
@@ -30,7 +32,7 @@ export default function Input({
   return (
     <div>
       {label && (
-        <label htmlFor={inputId} className="block mb-2 ml-2 font-bold text-14 text-typography-dark">
+        <label htmlFor={inputId} className={`block mb-2 ml-2 font-bold text-14 text-typography-dark ${labelClassName}`}>
           {label}
           {required && <span> (*필수)</span>}
         </label>

--- a/src/components/ui/input/Input.tsx
+++ b/src/components/ui/input/Input.tsx
@@ -6,7 +6,7 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   required?: boolean;
   className?: string;
   labelClassName?: string;
-  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
   onEnterPress?: () => void;
 }
 

--- a/src/components/ui/table/CustomTable.tsx
+++ b/src/components/ui/table/CustomTable.tsx
@@ -36,39 +36,39 @@ export default function TableItem<T>({
   };
 
   return (
-    <div className={`${className} space-y-5`}>
+    <table className={`${className} space-y-5`}>
       {/* 테이블 헤더 */}
-      <div className="grid grid-cols-[repeat(auto-fit,_minmax(0,_1fr))] bg-background shadow-custom rounded-10 p-4">
+      <thead className="grid grid-cols-[repeat(auto-fit,_minmax(0,_1fr))] bg-background shadow-custom rounded-10 p-4">
         {columns.map((column) => (
-          <div
+          <tr
             key={column.id}
             className={`font-bold text-typography-dark text-14 flex items-center justify-${
               column.align || 'center'
             } ${column.width ? `w-[${column.width}]` : ''}`}>
-            {column.label}
-          </div>
+            <th>{column.label}</th>
+          </tr>
         ))}
-      </div>
+      </thead>
 
       {/* 테이블 바디 */}
-      <div className="space-y-5">
+      <tbody className="space-y-5">
         {items.map((item, itemIndex) => (
-          <div
+          <tr
             key={itemIndex}
             className="bg-white grid grid-cols-[repeat(auto-fit,_minmax(0,_1fr))] p-4 hover:bg-button-hover transition-colors rounded-10 cursor-pointer"
             onClick={() => handleItemClick(item)}>
             {columns.map((column) => (
-              <div
+              <td
                 key={`${itemIndex}-${column.id}`}
                 className={`flex items-center justify-${
                   column.align || 'center'
                 } ${column.width ? `w-[${column.width}]` : ''} font-medium text-typography-dark text-11 `}>
                 {renderCell(column, item, itemIndex)}
-              </div>
+              </td>
             ))}
-          </div>
+          </tr>
         ))}
-      </div>
-    </div>
+      </tbody>
+    </table>
   );
 }

--- a/src/components/ui/table/CustomTable.tsx
+++ b/src/components/ui/table/CustomTable.tsx
@@ -36,7 +36,7 @@ export default function TableItem<T>({
   };
 
   return (
-    <table className={`${className} space-y-5`}>
+    <table className={`${className} flex flex-col gap-5`}>
       {/* 테이블 헤더 */}
       <thead className="grid grid-cols-[repeat(auto-fit,_minmax(0,_1fr))] bg-background shadow-custom rounded-10 p-4">
         {columns.map((column) => (

--- a/src/components/ui/textarea/TextArea.tsx
+++ b/src/components/ui/textarea/TextArea.tsx
@@ -1,0 +1,57 @@
+import { ChangeEvent, TextareaHTMLAttributes, useId } from 'react';
+
+interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  label?: string;
+  name?: string;
+  required?: boolean;
+  className?: string;
+  labelClassName?: string;
+  rows?: number;
+  onChange?: (e: ChangeEvent<HTMLTextAreaElement>) => void;
+  onEnterPress?: () => void;
+}
+
+export default function Textarea({
+  label,
+  name,
+  value,
+  className = '',
+  labelClassName = '',
+  required = false,
+  rows = 4,
+  onChange,
+  onEnterPress,
+  ...props
+}: TextareaProps) {
+  const textareaId = useId();
+
+  const handleKeyUp = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && e.ctrlKey && onEnterPress) {
+      onEnterPress();
+    }
+  };
+
+  return (
+    <div>
+      {label && (
+        <label
+          htmlFor={textareaId}
+          className={`block mb-2 ml-2 font-bold text-14 text-typography-dark ${labelClassName}`}>
+          {label}
+          {required && <span> (*필수)</span>}
+        </label>
+      )}
+      <textarea
+        id={textareaId}
+        className={`w-full bg-background border-[0.5px] border-typography-gray rounded-15 px-4 py-3 placeholder:text-typography-gray focus:border-typography-dark focus:outline-none ${className}`}
+        value={value}
+        name={name}
+        onChange={onChange}
+        onKeyUp={handleKeyUp}
+        required={required}
+        rows={rows}
+        {...props}
+      />
+    </div>
+  );
+}

--- a/src/pages/project/ProjectCreatePage.tsx
+++ b/src/pages/project/ProjectCreatePage.tsx
@@ -1,22 +1,36 @@
+import { useNavigate } from 'react-router-dom';
 import ProjectCreateForm from '@/pages/project/_components/ProjectCreateForm';
 import { useGenerateProject } from '@/store/queries/project/useProjectMutations';
 import { useUserProfile } from '@/store/queries/user/useUserQueries';
 import { GenerateProject } from '@/types/project.type';
+import { ROUTES } from '@/constants';
 
 export default function ProjectCreatePage() {
+  const navigate = useNavigate();
   const { data: userData, isPending, isError } = useUserProfile();
   const generateProject = useGenerateProject();
 
-  const handleGenerateProject = (formData: GenerateProject) => {
+  const handleGenerateProject = (formData: GenerateProject, actionType: 'register' | 'test') => {
     generateProject.mutate(formData, {
       onSuccess: (response) => {
         // TODO: alert나 toast로 변경
         alert(response.message);
+
+        const projectId = response.data?.projectId;
+        if (actionType === 'register') {
+          navigate(ROUTES.PROJECTS);
+        } else if (actionType === 'test' && projectId) {
+          navigate(ROUTES.TESTS); // TODO: 바꿔야됨 일단 테스트용
+        }
       },
       onError: (error) => {
         alert(error?.message);
       }
     });
+  };
+
+  const handleCancelProject = () => {
+    navigate(ROUTES.HOME); // TODO: 바꿔야할 수도 있음
   };
 
   if (isPending) {
@@ -32,7 +46,7 @@ export default function ProjectCreatePage() {
   return (
     <div>
       <h1 className="font-bm text-16 text-typography-dark pl-4 pb-8">새 프로젝트 생성</h1>
-      <ProjectCreateForm username={userData.username} onSubmit={handleGenerateProject} />
+      <ProjectCreateForm username={userData.username} onSubmit={handleGenerateProject} onCancel={handleCancelProject} />
     </div>
   );
 }

--- a/src/pages/project/ProjectCreatePage.tsx
+++ b/src/pages/project/ProjectCreatePage.tsx
@@ -1,3 +1,10 @@
+import ProjectCreateForm from '@/pages/project/_components/ProjectCreateForm';
+
 export default function ProjectCreatePage() {
-  return <div>프로젝트생성페이지</div>;
+  return (
+    <div>
+      <h1 className="font-bm text-16 text-typography-dark pl-4">새 프로젝트 생성</h1>
+      <ProjectCreateForm />
+    </div>
+  );
 }

--- a/src/pages/project/ProjectCreatePage.tsx
+++ b/src/pages/project/ProjectCreatePage.tsx
@@ -20,17 +20,22 @@ export default function ProjectCreatePage() {
         if (actionType === 'register') {
           navigate(ROUTES.PROJECTS);
         } else if (actionType === 'test' && projectId) {
-          navigate(ROUTES.TESTS); // TODO: 바꿔야됨 일단 테스트용
+          navigate(ROUTES.TESTS); // TODO: 테스트 세부 페이지로 바꿔야됨 일단 테스트용
         }
       },
-      onError: (error) => {
-        alert(error?.message);
+      onError: () => {
+        alert('필수 입력란을 모두 입력해주세요.');
       }
     });
   };
 
   const handleCancelProject = () => {
-    navigate(ROUTES.HOME); // TODO: 바꿔야할 수도 있음
+    // TODO: 나중에 현준이가 만든 팝업창으로 바꾸기 우선 confirm()으로 구현
+    const isConfirmed = confirm('프로젝트 생성을 취소하시겠습니까?');
+    if (isConfirmed) {
+      navigate(ROUTES.HOME); // TODO: 바꿔야할 수도 있음
+    }
+    return;
   };
 
   if (isPending) {

--- a/src/pages/project/ProjectCreatePage.tsx
+++ b/src/pages/project/ProjectCreatePage.tsx
@@ -1,10 +1,38 @@
 import ProjectCreateForm from '@/pages/project/_components/ProjectCreateForm';
+import { useGenerateProject } from '@/store/queries/project/useProjectMutations';
+import { useUserProfile } from '@/store/queries/user/useUserQueries';
+import { GenerateProject } from '@/types/project.type';
 
 export default function ProjectCreatePage() {
+  const { data: userData, isPending, isError } = useUserProfile();
+  const generateProject = useGenerateProject();
+
+  const handleGenerateProject = (formData: GenerateProject) => {
+    generateProject.mutate(formData, {
+      onSuccess: (response) => {
+        // TODO: alert나 toast로 변경
+        alert(response.message);
+      },
+      onError: (error) => {
+        alert(error?.message);
+      }
+    });
+  };
+
+  if (isPending) {
+    return <div>로딩중...</div>;
+  }
+  if (isError) {
+    return <div>프로젝트 관리자명을 불러오는 데 오류가 발생했습니다.</div>;
+  }
+  if (!userData) {
+    return <div>사용자 정보를 찾을 수 없습니다.</div>;
+  }
+
   return (
     <div>
       <h1 className="font-bm text-16 text-typography-dark pl-4 pb-8">새 프로젝트 생성</h1>
-      <ProjectCreateForm />
+      <ProjectCreateForm username={userData.username} onSubmit={handleGenerateProject} />
     </div>
   );
 }

--- a/src/pages/project/ProjectCreatePage.tsx
+++ b/src/pages/project/ProjectCreatePage.tsx
@@ -3,7 +3,7 @@ import ProjectCreateForm from '@/pages/project/_components/ProjectCreateForm';
 export default function ProjectCreatePage() {
   return (
     <div>
-      <h1 className="font-bm text-16 text-typography-dark pl-4">새 프로젝트 생성</h1>
+      <h1 className="font-bm text-16 text-typography-dark pl-4 pb-8">새 프로젝트 생성</h1>
       <ProjectCreateForm />
     </div>
   );

--- a/src/pages/project/ProjectMangePage.tsx
+++ b/src/pages/project/ProjectMangePage.tsx
@@ -1,10 +1,10 @@
+import { useNavigate } from 'react-router-dom';
 import TableItem from '@/components/ui/table/CustomTable';
-import { ROUTES } from '@/constants';
 import ProjectTitle from '@/pages/project/_components/ProjectTitle';
 import StatusBadge from '@/pages/project/_components/StatusBadge';
+import { ROUTES } from '@/constants';
 import { useGetProjectList } from '@/store/queries/project/useProjectQueries';
 import { ProjectListData } from '@/types/project.type';
-import { useNavigate } from 'react-router-dom';
 
 const columns = [
   { id: 'projectName', label: '프로젝트 명' },

--- a/src/pages/project/_components/DesignSourceSection.tsx
+++ b/src/pages/project/_components/DesignSourceSection.tsx
@@ -1,0 +1,61 @@
+import Input from '@/components/ui/input/Input';
+import { ChangeEvent } from 'react';
+
+interface DesignSourceProps {
+  figmaUrl: string;
+  serviceUrl: string;
+  rootFigmaPage: string;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  disabled?: boolean;
+  containerClassName?: string;
+}
+
+export default function DesignSourceSection({
+  figmaUrl,
+  serviceUrl,
+  rootFigmaPage,
+  onChange,
+  disabled = false,
+  containerClassName = 'border-[0.5px] border-typography-gray rounded-15 px-6 pt-6 pb-8 space-y-4'
+}: DesignSourceProps) {
+  return (
+    <div>
+      <h2 className="font-bold text-14 text-typography-dark pl-4 py-3">디자인 소스</h2>
+      <div className={containerClassName}>
+        <Input
+          label="피그마 시안 URL"
+          name="figmaUrl"
+          value={figmaUrl}
+          required
+          onChange={onChange}
+          disabled={disabled}
+          labelClassName="font-medium text-11"
+          className="h-8 rounded-md"
+          type="url"
+        />
+        <Input
+          label="배포된 서비스 URL"
+          name="serviceUrl"
+          value={serviceUrl}
+          required
+          onChange={onChange}
+          disabled={disabled}
+          labelClassName="font-medium text-11"
+          className="h-8 rounded-md"
+          type="url"
+        />
+        <Input
+          label="피그마 루트 페이지"
+          name="rootFigmaPage"
+          value={rootFigmaPage}
+          required
+          onChange={onChange}
+          disabled={disabled}
+          labelClassName="font-medium text-11"
+          className="h-8 rounded-md"
+          type="text"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/project/_components/ProjectCreateForm.tsx
+++ b/src/pages/project/_components/ProjectCreateForm.tsx
@@ -11,8 +11,8 @@ export default function ProjectCreateForm() {
   };
 
   return (
-    <form onSubmit={handleSubmitProjectCreateForm}>
-      <section>
+    <form onSubmit={handleSubmitProjectCreateForm} className="flex flex-col gap-6">
+      <section className="space-y-5">
         <Input label="프로젝트명" required onChange={handleChange} />
         <Input label="프로젝트 관리자" required onChange={handleChange} />
         <Input label="테스트 예상 시작일" onChange={handleChange} />
@@ -20,17 +20,35 @@ export default function ProjectCreateForm() {
         <Input label="설명" onChange={handleChange} />
       </section>
 
-      <section>
+      <section className="flex flex-col gap-5">
         <div>
-          <h2 className="font-bm text-14 text-typography-dark pl-4">디자인 소스</h2>
-          <form className="border-[0.5px] border-typography-gray rounded-15 px-6 py-7">
-            <Input label="피그마 시안 URL" onChange={handleChange} className="h-8 rounded-md" />
-            <Input label="배포된 서비스 URL" onChange={handleChange} />
-            <Input label="피그마 루트 페이지" onChange={handleChange} />
+          <h2 className="font-bold text-14 text-typography-dark pl-4 py-3">디자인 소스</h2>
+          <form className="border-[0.5px] border-typography-gray rounded-15 px-6 pt-6 pb-8 space-y-4">
+            <Input
+              label="피그마 시안 URL"
+              onChange={handleChange}
+              labelClassName="font-medium text-11"
+              className="h-8 rounded-md"
+              type="url"
+            />
+            <Input
+              label="배포된 서비스 URL"
+              onChange={handleChange}
+              labelClassName="font-medium text-11"
+              className="h-8 rounded-md"
+              type="url"
+            />
+            <Input
+              label="피그마 루트 페이지"
+              onChange={handleChange}
+              labelClassName="font-medium text-11"
+              className="h-8 rounded-md"
+              type="text"
+            />
           </form>
         </div>
 
-        <div>
+        <div className="flex justify-center gap-10 children:px-8 ">
           <Button text="등록" />
           <Button text="등록 후 테스트하기" />
           <Button text="취소" />

--- a/src/pages/project/_components/ProjectCreateForm.tsx
+++ b/src/pages/project/_components/ProjectCreateForm.tsx
@@ -83,7 +83,7 @@ export default function ProjectCreateForm({ username, onSubmit, onCancel }: Proj
           onChange={handleChange}
         />
 
-        <div className="flex justify-center gap-10 children:px-8 ">
+        <div className="flex justify-center gap-10 children:px-8 children:font-medium">
           <Button text="등록" type="button" data-submit-type="register" onClick={handleRegisterProject} />
           <Button
             text="등록 후 테스트 생성하기"

--- a/src/pages/project/_components/ProjectCreateForm.tsx
+++ b/src/pages/project/_components/ProjectCreateForm.tsx
@@ -3,17 +3,19 @@ import Input from '@/components/ui/input/Input';
 import Textarea from '@/components/ui/textarea/TextArea';
 import DesignSourceSection from '@/pages/project/_components/DesignSourceSection';
 import { GenerateProject } from '@/types/project.type';
+import { getFormattedToday } from '@/utils/format';
 import { ChangeEvent, FormEvent, useState } from 'react';
 
 interface ProjectCreateFormPropsType {
   username: string;
-  onSubmit: (data: GenerateProject) => void;
+  onSubmit: (data: GenerateProject, actionType: 'register' | 'test') => void;
+  onCancel: () => void;
 }
 
-export default function ProjectCreateForm({ username, onSubmit }: ProjectCreateFormPropsType) {
+export default function ProjectCreateForm({ username, onSubmit, onCancel }: ProjectCreateFormPropsType) {
   const [formData, setFormData] = useState<GenerateProject>({
     projectName: '',
-    administrator: username,
+    expectedTestExecution: '',
     projectEnd: '',
     description: '',
     figmaUrl: '',
@@ -31,12 +33,15 @@ export default function ProjectCreateForm({ username, onSubmit }: ProjectCreateF
 
   const handleSubmitProjectCreateForm = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    onSubmit(formData);
-    console.log('프로젝트생성form 제출');
   };
 
-  // TODO: 테스트 예상 시작일은 프로젝트 마감일 전이어야 하고,
-  // //프로젝트 생성일보다 앞설 수 없음. 프로젝트 마감일도 프로젝트 생성일보다 앞설 수 없음
+  const handleRegisterProject = () => {
+    onSubmit(formData, 'register');
+  };
+
+  const handleRegisterAndTest = () => {
+    onSubmit(formData, 'test');
+  };
 
   return (
     <form onSubmit={handleSubmitProjectCreateForm} className="flex flex-col gap-6">
@@ -50,7 +55,14 @@ export default function ProjectCreateForm({ username, onSubmit }: ProjectCreateF
           disabled
           className="bg-button-hover text-typography-gray"
         />
-        <Input label="테스트 예상 시작일" onChange={handleChange} type="date" />
+        <Input
+          label="테스트 예상 시작일"
+          name="expectedTestExecution"
+          value={formData.expectedTestExecution}
+          onChange={handleChange}
+          type="date"
+          min={getFormattedToday()}
+        />
         <Input
           label="프로젝트 마감일"
           name="projectEnd"
@@ -58,6 +70,7 @@ export default function ProjectCreateForm({ username, onSubmit }: ProjectCreateF
           required
           type="date"
           onChange={handleChange}
+          min={getFormattedToday()}
         />
         <Textarea label="설명" name="description" value={formData.description} onChange={handleChange} />
       </section>
@@ -71,9 +84,14 @@ export default function ProjectCreateForm({ username, onSubmit }: ProjectCreateF
         />
 
         <div className="flex justify-center gap-10 children:px-8 ">
-          <Button text="등록" type="submit" data-submit-type="register" />
-          <Button text="등록 후 테스트하기" type="submit" data-submit-type="test after register" />
-          <Button text="취소" type="button" data-submit-type="cancel" />
+          <Button text="등록" type="button" data-submit-type="register" onClick={handleRegisterProject} />
+          <Button
+            text="등록 후 테스트하기"
+            type="button"
+            data-submit-type="test after register"
+            onClick={handleRegisterAndTest}
+          />
+          <Button text="취소" type="button" data-submit-type="cancel" onClick={onCancel} />
         </div>
       </section>
     </form>

--- a/src/pages/project/_components/ProjectCreateForm.tsx
+++ b/src/pages/project/_components/ProjectCreateForm.tsx
@@ -1,5 +1,7 @@
 import Button from '@/components/ui/button/Button';
 import Input from '@/components/ui/input/Input';
+import Textarea from '@/components/ui/textarea/TextArea';
+import DesignSourceSection from '@/pages/project/_components/DesignSourceSection';
 import { GenerateProject } from '@/types/project.type';
 import { ChangeEvent, FormEvent, useState } from 'react';
 
@@ -19,7 +21,7 @@ export default function ProjectCreateForm({ username, onSubmit }: ProjectCreateF
     rootFigmaPage: ''
   });
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
     setFormData((prevData) => ({
       ...prevData,
@@ -50,45 +52,16 @@ export default function ProjectCreateForm({ username, onSubmit }: ProjectCreateF
           type="date"
           onChange={handleChange}
         />
-        <Input label="설명" name="description" value={formData.description} onChange={handleChange} />
+        <Textarea label="설명" name="description" value={formData.description} onChange={handleChange} />
       </section>
 
       <section className="flex flex-col gap-5">
-        <div>
-          <h2 className="font-bold text-14 text-typography-dark pl-4 py-3">디자인 소스</h2>
-          <div className="border-[0.5px] border-typography-gray rounded-15 px-6 pt-6 pb-8 space-y-4">
-            <Input
-              label="피그마 시안 URL"
-              name="figmaUrl"
-              value={formData.figmaUrl}
-              required
-              onChange={handleChange}
-              labelClassName="font-medium text-11"
-              className="h-8 rounded-md"
-              type="url"
-            />
-            <Input
-              label="배포된 서비스 URL"
-              name="serviceUrl"
-              value={formData.serviceUrl}
-              required
-              onChange={handleChange}
-              labelClassName="font-medium text-11"
-              className="h-8 rounded-md"
-              type="url"
-            />
-            <Input
-              label="피그마 루트 페이지"
-              name="rootFigmaPage"
-              value={formData.rootFigmaPage}
-              required
-              onChange={handleChange}
-              labelClassName="font-medium text-11"
-              className="h-8 rounded-md"
-              type="text"
-            />
-          </div>
-        </div>
+        <DesignSourceSection
+          figmaUrl={formData.figmaUrl}
+          serviceUrl={formData.serviceUrl}
+          rootFigmaPage={formData.rootFigmaPage}
+          onChange={handleChange}
+        />
 
         <div className="flex justify-center gap-10 children:px-8 ">
           <Button text="등록" type="submit" data-submit-type="register" />

--- a/src/pages/project/_components/ProjectCreateForm.tsx
+++ b/src/pages/project/_components/ProjectCreateForm.tsx
@@ -1,0 +1,41 @@
+import Button from '@/components/ui/button/Button';
+import Input from '@/components/ui/input/Input';
+
+export default function ProjectCreateForm() {
+  const handleChange = () => {
+    console.log('input에 글자 입력');
+  };
+
+  const handleSubmitProjectCreateForm = () => {
+    console.log('프로젝트생성form 제출');
+  };
+
+  return (
+    <form onSubmit={handleSubmitProjectCreateForm}>
+      <section>
+        <Input label="프로젝트명" required onChange={handleChange} />
+        <Input label="프로젝트 관리자" required onChange={handleChange} />
+        <Input label="테스트 예상 시작일" onChange={handleChange} />
+        <Input label="프로젝트 마감일" onChange={handleChange} />
+        <Input label="설명" onChange={handleChange} />
+      </section>
+
+      <section>
+        <div>
+          <h2 className="font-bm text-14 text-typography-dark pl-4">디자인 소스</h2>
+          <form className="border-[0.5px] border-typography-gray rounded-15 px-6 py-7">
+            <Input label="피그마 시안 URL" onChange={handleChange} className="h-8 rounded-md" />
+            <Input label="배포된 서비스 URL" onChange={handleChange} />
+            <Input label="피그마 루트 페이지" onChange={handleChange} />
+          </form>
+        </div>
+
+        <div>
+          <Button text="등록" />
+          <Button text="등록 후 테스트하기" />
+          <Button text="취소" />
+        </div>
+      </section>
+    </form>
+  );
+}

--- a/src/pages/project/_components/ProjectCreateForm.tsx
+++ b/src/pages/project/_components/ProjectCreateForm.tsx
@@ -1,31 +1,67 @@
 import Button from '@/components/ui/button/Button';
 import Input from '@/components/ui/input/Input';
+import { GenerateProject } from '@/types/project.type';
+import { ChangeEvent, FormEvent, useState } from 'react';
 
-export default function ProjectCreateForm() {
-  const handleChange = () => {
-    console.log('input에 글자 입력');
+interface ProjectCreateFormPropsType {
+  username: string;
+  onSubmit: (data: GenerateProject) => void;
+}
+
+export default function ProjectCreateForm({ username, onSubmit }: ProjectCreateFormPropsType) {
+  const [formData, setFormData] = useState<GenerateProject>({
+    projectName: '',
+    administrator: username,
+    projectEnd: '',
+    description: '',
+    figmaUrl: '',
+    serviceUrl: '',
+    rootFigmaPage: ''
+  });
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prevData) => ({
+      ...prevData,
+      [name]: value
+    }));
   };
 
-  const handleSubmitProjectCreateForm = () => {
+  const handleSubmitProjectCreateForm = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    onSubmit(formData);
     console.log('프로젝트생성form 제출');
   };
+
+  // TODO: 테스트 예상 시작일은 프로젝트 마감일 전이어야 하고,
+  // //프로젝트 생성일보다 앞설 수 없음. 프로젝트 마감일도 프로젝트 생성일보다 앞설 수 없음
 
   return (
     <form onSubmit={handleSubmitProjectCreateForm} className="flex flex-col gap-6">
       <section className="space-y-5">
-        <Input label="프로젝트명" required onChange={handleChange} />
-        <Input label="프로젝트 관리자" required onChange={handleChange} />
-        <Input label="테스트 예상 시작일" onChange={handleChange} />
-        <Input label="프로젝트 마감일" onChange={handleChange} />
-        <Input label="설명" onChange={handleChange} />
+        <Input label="프로젝트명" required name="projectName" value={formData.projectName} onChange={handleChange} />
+        <Input label="프로젝트 관리자" required name="username" value={username} disabled className="bg-button-hover" />
+        <Input label="테스트 예상 시작일" onChange={handleChange} type="date" />
+        <Input
+          label="프로젝트 마감일"
+          name="projectEnd"
+          value={formData.projectEnd}
+          required
+          type="date"
+          onChange={handleChange}
+        />
+        <Input label="설명" name="description" value={formData.description} onChange={handleChange} />
       </section>
 
       <section className="flex flex-col gap-5">
         <div>
           <h2 className="font-bold text-14 text-typography-dark pl-4 py-3">디자인 소스</h2>
-          <form className="border-[0.5px] border-typography-gray rounded-15 px-6 pt-6 pb-8 space-y-4">
+          <div className="border-[0.5px] border-typography-gray rounded-15 px-6 pt-6 pb-8 space-y-4">
             <Input
               label="피그마 시안 URL"
+              name="figmaUrl"
+              value={formData.figmaUrl}
+              required
               onChange={handleChange}
               labelClassName="font-medium text-11"
               className="h-8 rounded-md"
@@ -33,6 +69,9 @@ export default function ProjectCreateForm() {
             />
             <Input
               label="배포된 서비스 URL"
+              name="serviceUrl"
+              value={formData.serviceUrl}
+              required
               onChange={handleChange}
               labelClassName="font-medium text-11"
               className="h-8 rounded-md"
@@ -40,18 +79,21 @@ export default function ProjectCreateForm() {
             />
             <Input
               label="피그마 루트 페이지"
+              name="rootFigmaPage"
+              value={formData.rootFigmaPage}
+              required
               onChange={handleChange}
               labelClassName="font-medium text-11"
               className="h-8 rounded-md"
               type="text"
             />
-          </form>
+          </div>
         </div>
 
         <div className="flex justify-center gap-10 children:px-8 ">
-          <Button text="등록" />
-          <Button text="등록 후 테스트하기" />
-          <Button text="취소" />
+          <Button text="등록" type="submit" data-submit-type="register" />
+          <Button text="등록 후 테스트하기" type="submit" data-submit-type="test after register" />
+          <Button text="취소" type="button" data-submit-type="cancel" />
         </div>
       </section>
     </form>

--- a/src/pages/project/_components/ProjectCreateForm.tsx
+++ b/src/pages/project/_components/ProjectCreateForm.tsx
@@ -42,7 +42,14 @@ export default function ProjectCreateForm({ username, onSubmit }: ProjectCreateF
     <form onSubmit={handleSubmitProjectCreateForm} className="flex flex-col gap-6">
       <section className="space-y-5">
         <Input label="프로젝트명" required name="projectName" value={formData.projectName} onChange={handleChange} />
-        <Input label="프로젝트 관리자" required name="username" value={username} disabled className="bg-button-hover" />
+        <Input
+          label="프로젝트 관리자"
+          required
+          name="username"
+          value={username}
+          disabled
+          className="bg-button-hover text-typography-gray"
+        />
         <Input label="테스트 예상 시작일" onChange={handleChange} type="date" />
         <Input
           label="프로젝트 마감일"

--- a/src/pages/project/_components/ProjectCreateForm.tsx
+++ b/src/pages/project/_components/ProjectCreateForm.tsx
@@ -86,7 +86,7 @@ export default function ProjectCreateForm({ username, onSubmit, onCancel }: Proj
         <div className="flex justify-center gap-10 children:px-8 ">
           <Button text="등록" type="button" data-submit-type="register" onClick={handleRegisterProject} />
           <Button
-            text="등록 후 테스트하기"
+            text="등록 후 테스트 생성하기"
             type="button"
             data-submit-type="test after register"
             onClick={handleRegisterAndTest}

--- a/src/pages/setting/ProfileEditPage.tsx
+++ b/src/pages/setting/ProfileEditPage.tsx
@@ -16,8 +16,8 @@ export default function ProfileEditPage() {
         // TODO: alert나 toast로 변경
         alert(response.message);
       },
-      onError: (error) => {
-        alert(error?.message);
+      onError: () => {
+        alert('입력하신 내용 중 형식에 맞지 않는 항목이 있습니다.');
       }
     });
   };

--- a/src/pages/setting/_components/ProfileForm.tsx
+++ b/src/pages/setting/_components/ProfileForm.tsx
@@ -62,7 +62,8 @@ export default function ProfileForm({ initialData, onSubmit }: ProfileFormProps)
         name="phoneNumber"
         value={formData.phoneNumber}
         onChange={handleChange}
-        className="border-none shadow-custom focus:bg-white"
+        className="border-none shadow-custom focus:bg-white placeholder:text-14"
+        placeholder="eg) 00(0)-0000-0000"
       />
 
       <Button text="등록" type="submit" className="w-48 block mx-auto font-medium text-11 text-typography-dark" />

--- a/src/pages/test/TestManagePage.tsx
+++ b/src/pages/test/TestManagePage.tsx
@@ -1,3 +1,9 @@
+import TestTitle from '@/pages/test/_components/TestTitle';
+
 export default function TestManagePage() {
-  return <div>테스트관리페이지</div>;
+  return (
+    <div className="w-[90%] flex flex-col m-auto">
+      <TestTitle />
+    </div>
+  );
 }

--- a/src/pages/test/_components/TestTitle.tsx
+++ b/src/pages/test/_components/TestTitle.tsx
@@ -1,0 +1,10 @@
+import TestIcon from '@/assets/icons/test.svg';
+
+export default function TestTitle() {
+  return (
+    <h1 className="flex gap-4 items-center pl-4 pb-10">
+      <img src={TestIcon} alt="project icon" />
+      <span className="font-bm text-20">테스트 관리</span>
+    </h1>
+  );
+}

--- a/src/store/queries/project/useProjectMutations.ts
+++ b/src/store/queries/project/useProjectMutations.ts
@@ -1,1 +1,21 @@
 // crud 공간
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { API_ENDPOINTS } from '@/constants';
+import axiosInstance from '@/services/api/axios';
+import { GenerateProject } from '@/types/project.type';
+
+// 프로젝트 생성
+export const useGenerateProject = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (projectData: GenerateProject) => {
+      const response = await axiosInstance.post(API_ENDPOINTS.PROJECTS.CREATE, projectData);
+      return response.data;
+    },
+    onSuccess: () => {
+      // 프로젝트 리스트에 업데이트
+      queryClient.invalidateQueries({ queryKey: ['projects'] });
+    }
+  });
+};

--- a/src/types/project.type.ts
+++ b/src/types/project.type.ts
@@ -25,6 +25,7 @@ export interface ProjectsParams {
 
 export interface GenerateProject {
   projectName: string;
+  expectedTestExecution: string;
   projectEnd: string;
   description: string;
   figmaUrl: string;

--- a/src/types/project.type.ts
+++ b/src/types/project.type.ts
@@ -22,3 +22,13 @@ export interface ProjectsParams {
   sortBy?: string;
   cursor?: number | null;
 }
+
+export interface GenerateProject {
+  projectName: string;
+  projectEnd: string;
+  description: string;
+  figmaUrl: string;
+  serviceUrl: string;
+  rootFigmaPage: string;
+  administrator?: string;
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -3,7 +3,7 @@ export const formatDate = (date: Date | string): string => {
   return d.toLocaleDateString('ko-KR', {
     year: 'numeric',
     month: 'long',
-    day: 'numeric',
+    day: 'numeric'
   });
 };
 
@@ -14,10 +14,16 @@ export const formatDateTime = (date: Date | string): string => {
     month: 'long',
     day: 'numeric',
     hour: '2-digit',
-    minute: '2-digit',
+    minute: '2-digit'
   });
 };
 
-export const formatNumber = (number: number): string => {
-  return new Intl.NumberFormat('ko-KR').format(number);
+// 오늘 이후로만 선택할 수 있게 날짜 설정하는 함수
+export const getFormattedToday = (): string => {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, '0');
+  const day = String(today.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
 };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,5 +19,10 @@ export default {
       fontSize: typography.fontSize
     }
   },
-  plugins: []
+  plugins: [
+    function ({ addVariant }) {
+      addVariant('children', '& > *'); // 직계 자식 선택
+      addVariant('all', '& *'); // 모든 후손 선택
+    }
+  ]
 };


### PR DESCRIPTION
## 🛰️ Issue Number
이슈번호: #22

## 🪐 작업 내용
- tailwind plugin 작성해서 직계 자식에게 css 스타일 상속할 수 있도록 보완
- 프로젝트 생성 페이지 퍼블리싱
  - 입력 form은 page의 _components로 분리
  - 입력 form에서도 디자인 소스 section은 세부 페이지, 수정 페이지에서도 쓰일 것이기 때문에 재사용성을 고려해 따로 또 분리
   - 테스트 예정일, 프로젝트 마감일을 우선 `<input type='date' />`로 해놨는데, 오늘 이후로만 선택할 수 있게 `src/util` 폴더에 오늘 날짜를 가져오는 함수 `getFormattedToday` 함수 정의 후, `<input type=date min={getFormattedToday()}` />로 사용
  - 어떤 작업을 할 때 '~하시겠습니까?'에 대한 선택을 할 수 있도록 `confirm()` 사용해서 일단 처리
 -  현재 경로를 가져와 사이드바의 SidebarData.ts에 있는 title과 매칭시켜 현재 페이지 이름 연결
 - Input 컴포넌트에서 label 부분이 페이지마다 폰트 스타일이 달라 `labelClassName` props 추가
 - 프로젝트 생성 완료 -> 프로젝트 관리 페이지로 navigate
 - 프로젝트 취소 -> 대시보드 페이지로 navigate
 - 프로젝트 생성 후 테스트 생성 -> 우선은 테스트 관리 페이지로 라우팅 했는데 추후에 해당 테스트 상세 페이지로 이동시킬 예정
 - 
<작업 사진>
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/52fb7d80-2eb1-4b78-8d75-83fac517b265" />
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/066012ad-1e10-4972-92ba-1b05477ebda7" />
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/56b68d41-9d8a-459e-a293-eb899712da56" />
<img width="202" alt="image" src="https://github.com/user-attachments/assets/17a86ad2-cd8a-44f8-a762-eb2605f6b69f" />

```
// 오늘 이후로만 선택할 수 있게 날짜 설정하는 함수
export const getFormattedToday = (): string => {
  const today = new Date();
  const year = today.getFullYear();
  const month = String(today.getMonth() + 1).padStart(2, '0');
  const day = String(today.getDate()).padStart(2, '0');

  return `${year}-${month}-${day}`;
};
```

<커밋 설명>
- `<input type='date' />` 사용한 부분을 추후에 라이브러리로 대체하는 방안 고려
- `alert()`, `confirm()`이 쓰이고 있는 부분 다 커스텀 컴포넌트로 대체 예정
- 프로젝트 세부 페이지는 아직 시안 완성이 안돼서 테스트 관리 페이지 개발 들어갈 예정
- 그리고 프로젝트 관리 페이지는 api는 무한스크롤 가능하도록 짜 주셨는데 디자이너분이랑은 무한스크롤 안하기로 했던 것 같아서 일단 구현 안했습니다. 

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] 코드 스타일을 eslint/prettier로 맞췄나요?