### PR TITLE
[ #45 | Fix ] 진행률 bar 계산식 수정

### DIFF
--- a/src/components/ui/progressBar/LinearProgressBar.tsx
+++ b/src/components/ui/progressBar/LinearProgressBar.tsx
@@ -1,5 +1,5 @@
 interface LinearProgressBarProps {
-  value: string;
+  value?: number;
   className?: string;
   color?: string;
   success?: number;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -45,7 +45,7 @@ export const ROUTES = {
   NEW_PROJECT: '/new-project',
   PROJECT_DETAIL: '/projects/:projectId',
   TESTS: '/tests',
-  TEST_DETAIL: '/tests/:testId',
+  TEST_DETAIL: '/tests/:projectId',
   SETTINGS: '/settings',
   PROFILE: '/settings/profile'
 };

--- a/src/pages/test/TestManagePage.tsx
+++ b/src/pages/test/TestManagePage.tsx
@@ -40,8 +40,9 @@ export default function TestManagePage() {
     setDateSort('');
   };
 
-  if (isPending) return <div>로딩 중...</div>;
-  if (isError) return <div>오류가 발생했습니다.</div>;
+  if (isPending) return <div className="col-span-3 text-center text-typography-gray text-16 pt-40">로딩 중...</div>;
+  if (isError)
+    return <div className="col-span-3 text-center text-typography-gray text-16 pt-40">오류가 발생했습니다.</div>;
 
   const tests = testList?.pages.flatMap((page) => page.tests) || [];
 

--- a/src/pages/test/_components/testList/TestList.tsx
+++ b/src/pages/test/_components/testList/TestList.tsx
@@ -1,6 +1,8 @@
 import { forwardRef } from 'react';
 import { TestData } from '@/types/test.type';
 import TestListItem from './TestListItem';
+import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '@/constants';
 
 interface TestListProps {
   tests: TestData[];
@@ -9,10 +11,22 @@ interface TestListProps {
 }
 
 const TestList = forwardRef<HTMLDivElement, TestListProps>(({ tests, isFetchingNextPage, hasNextPage }, ref) => {
+  const navigate = useNavigate();
+
+  const handleClickRegisterButton = (projectId: number) => {
+    navigate(ROUTES.TEST_DETAIL.replace(':projectId', projectId.toString()));
+  };
+
   return (
     <section className="grid grid-cols-3 gap-10">
       {tests.length > 0 ? (
-        tests.map((test) => <TestListItem key={test.projectId} data={test} />)
+        tests.map((test) => (
+          <TestListItem
+            key={test.projectId}
+            data={test}
+            handleClickRegisterButton={() => handleClickRegisterButton(test.projectId)}
+          />
+        ))
       ) : (
         <div className="col-span-3 text-center text-typography-gray text-16 py-20">입력하신 검색 결과가 없습니다.</div>
       )}

--- a/src/pages/test/_components/testList/TestListItem.tsx
+++ b/src/pages/test/_components/testList/TestListItem.tsx
@@ -18,10 +18,15 @@ export default function TestListItem({ data }: TestListItemProps) {
     totalMappingTest = 0
   } = data || {};
 
+  // progress bar를 위한 percentage 계산 함수
+  const calculatePercentage = (success: number, total: number) => {
+    return total === 0 ? 0 : Math.round((success / total) * 100);
+  };
+
   // 테스트 성공률 계산
-  const routingPercentage = Math.round((successRoutingTest / totalRoutingTest) * 100);
-  const interactionPercentage = Math.round((successInteractionTest / totalInteractionTest) * 100);
-  const mappingPercentage = Math.round((successMappingTest / totalMappingTest) * 100);
+  const routingPercentage = calculatePercentage(successRoutingTest, totalRoutingTest);
+  const interactionPercentage = calculatePercentage(successInteractionTest, totalInteractionTest);
+  const mappingPercentage = calculatePercentage(successMappingTest, totalMappingTest);
 
   // 총 테스트 계산
   const totalTests = totalRoutingTest + totalInteractionTest + totalMappingTest;
@@ -40,7 +45,7 @@ export default function TestListItem({ data }: TestListItemProps) {
         <li className="space-y-1">
           <p className="font-semibold text-11">라우팅 테스트</p>
           <LinearProgressBar
-            value={String(routingPercentage)}
+            value={routingPercentage}
             success={successRoutingTest}
             total={totalRoutingTest}
             color="bg-teal_1"
@@ -49,7 +54,7 @@ export default function TestListItem({ data }: TestListItemProps) {
         <li className="space-y-1">
           <p className="font-semibold text-11">인터랙션 테스트</p>
           <LinearProgressBar
-            value={String(interactionPercentage)}
+            value={interactionPercentage}
             success={successInteractionTest}
             total={totalInteractionTest}
             color="bg-purple_1"
@@ -58,7 +63,7 @@ export default function TestListItem({ data }: TestListItemProps) {
         <li className="space-y-1">
           <p className="font-semibold text-11">컴포넌트 테스트</p>
           <LinearProgressBar
-            value={String(mappingPercentage)}
+            value={mappingPercentage}
             success={successMappingTest}
             total={totalMappingTest}
             color="bg-brown_1"

--- a/src/pages/test/_components/testList/TestListItem.tsx
+++ b/src/pages/test/_components/testList/TestListItem.tsx
@@ -1,12 +1,14 @@
 import Button from '@/components/ui/button/Button';
 import LinearProgressBar from '@/components/ui/progressBar/LinearProgressBar';
 import { TestData } from '@/types/test.type';
+import { calculatePercentage } from '@/utils/useCalculateTestPercentage';
 
 interface TestListItemProps {
-  data?: TestData;
+  data: TestData;
+  handleClickRegisterButton: (projectId: number) => void;
 }
 
-export default function TestListItem({ data }: TestListItemProps) {
+export default function TestListItem({ data, handleClickRegisterButton }: TestListItemProps) {
   const {
     projectName: projectName = '테스트 프로젝트 이름',
     projectCreatedDate = '',
@@ -17,11 +19,6 @@ export default function TestListItem({ data }: TestListItemProps) {
     totalInteractionTest = 0,
     totalMappingTest = 0
   } = data || {};
-
-  // progress bar를 위한 percentage 계산 함수
-  const calculatePercentage = (success: number, total: number) => {
-    return total === 0 ? 0 : Math.round((success / total) * 100);
-  };
 
   // 테스트 성공률 계산
   const routingPercentage = calculatePercentage(successRoutingTest, totalRoutingTest);
@@ -73,7 +70,7 @@ export default function TestListItem({ data }: TestListItemProps) {
       <p className="font-medium text-11 text-typography-gray py-2">
         총 테스트 {successTests}/{totalTests} 통과
       </p>
-      <Button text="등록" className="w-full" />
+      <Button text="등록" className="w-full" onClick={() => handleClickRegisterButton(data.projectId)} />
     </div>
   );
 }

--- a/src/services/api/axios.ts
+++ b/src/services/api/axios.ts
@@ -58,8 +58,6 @@ axiosInstance.interceptors.response.use(
 
     // 401(권한x)이면서 아직 재시도 요청인 경우
     if (error.response?.status === 401 && !originalRequest._retry) {
-      console.log('(지울예정) 토큰 만료됨');
-
       if (isRefreshing) {
         return new Promise((resolve, reject) => {
           failQueue.push({
@@ -78,12 +76,10 @@ axiosInstance.interceptors.response.use(
 
       try {
         const response = await axiosInstance.post(API_ENDPOINTS.AUTH.REFRESH, {}, { withCredentials: true });
-        console.log('(지울예정) 토큰재발급응답', response.data);
 
         // 응답에서 새 access 호출
         const newAccessToken = response.data.data?.accessToken;
         if (!newAccessToken) throw new Error('accessToken 없음');
-        console.log('(지울예정) 새accessToken발급받음');
 
         // 새 토큰 저장 & 상태 업데이트
         localStorage.setItem('token', newAccessToken);
@@ -93,7 +89,6 @@ axiosInstance.interceptors.response.use(
         originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
         return axiosInstance(originalRequest);
       } catch (refreshError) {
-        console.log('(지울예정) 토큰갱신실패');
         processQueue(refreshError, null);
         store.dispatch(logout());
         window.location.href = ROUTES.LOGIN;

--- a/src/types/test.type.ts
+++ b/src/types/test.type.ts
@@ -1,5 +1,5 @@
 export interface TestData {
-  projectId?: number;
+  projectId: number;
   projectName?: string;
   successRoutingTest?: number;
   successInteractionTest?: number;

--- a/src/utils/useCalculateTestPercentage.ts
+++ b/src/utils/useCalculateTestPercentage.ts
@@ -1,0 +1,4 @@
+// progress bar를 위한 percentage 계산 함수
+export const calculatePercentage = (success: number, total: number) => {
+  return total === 0 ? 0 : Math.round((success / total) * 100);
+};


### PR DESCRIPTION
## 🛰️ Issue Number
이슈번호: #45

## 🪐 작업 내용

<작업 사진>
<img width="860" alt="image" src="https://github.com/user-attachments/assets/ffa0a298-d2b0-42e2-95db-7fcd854e2f1b" />


<구현 요약>
- progressBar에 진행률을 칠하기 위해 계산식을 세웠는데 totalRouring, totalInteracting, totalMapping이 0일 때 처리를 안해줬더니 무한대로 인식해서 100%로 칠해지는 것 같아서 `calculatePercentage` 함수 만들어서 success, total 인자를 받아 0일 경우의 상황 추가해 조건식 만들어서 해결했습니다.
- `calculatePercentage`은 utils로 뺐는데 필요없으면 나중에 testListItem 파일로 옮길게요. (프로젝트나 테스트 세부 페이지에서도 그래프가 쓰일 수 있으니...)
- '등록' 버튼 누르면 test 세부페이지로 라우팅 처리 했는데, 이 과정에서 routing 파일에서 동적라우팅 이름을 testId에서 projectId로 바꿨습니다. (백엔드 노션 명세서 참고)

<커밋 설명>



## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] 코드 스타일을 eslint/prettier로 맞췄나요?