### PR TITLE
Update deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,13 +9,26 @@ jobs:
     runs-on: ubuntu-latest
     container: pandoc/latex
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4  # 최신 버전 사용
 
       - name: Install mustache (to update the date)
         run: apk add ruby && gem install mustache
 
       - name: creates output
         run: sh ./build.sh
+
+      - name: Verify build output
+        run: |
+          if [ ! -d "output" ]; then
+            echo "Error: output directory not created"
+            exit 1
+          fi
+          if [ -z "$(ls -A output 2>/dev/null)" ]; then
+            echo "Error: output directory is empty"
+            exit 1
+          fi
+          echo "Build output verified successfully"
+          ls -la output/
 
       - name: Pushes to another repository
         id: push_directory
@@ -30,5 +43,10 @@ jobs:
           commit-message: ${{ github.event.commits[0].message }}
           target-branch: main
 
-      - name: Test get variable exported by push-to-another-repository
-        run: echo $DESTINATION_CLONED_DIRECTORY
+      - name: Verify push success
+        run: |
+          if [ -z "$DESTINATION_CLONED_DIRECTORY" ]; then
+            echo "Error: Push to destination repository may have failed"
+            exit 1
+          fi
+          echo "Push completed successfully to: $DESTINATION_CLONED_DIRECTORY"


### PR DESCRIPTION
## 🪐 작업 내용

<작업 사진>
actions 오류가 안 뜨는 원인을 정확히는 모르겠지만 저희 organization의 레포를 직접 배포할 수가 없어 우회하는 방법으로 이 레포를 제 레포로 fork 한 다음에 제 레포를 배포해서 그런지 fork한 레포에는 actions오류가 잘 뜹니다. 그래서 일단 클루드님의 도움을 받아 저희 organization의 workflow 파일을 수정하였습니다. 
안되면 다시 시도해보겠습니다. 


## 📚 Reference


## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
- [ ] 코드 스타일을 eslint/prettier로 맞췄나요?