### PR TITLE
[ #69 | Feat ] 캡스톤용 개발 완

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-icons": "^5.5.0",
         "react-redux": "^9.2.0",
         "react-router-dom": "^7.5.3",
+        "react-toastify": "^11.0.5",
         "recoil": "^0.7.7"
       },
       "devDependencies": {
@@ -5131,6 +5132,18 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-icons": "^5.5.0",
     "react-redux": "^9.2.0",
     "react-router-dom": "^7.5.3",
+    "react-toastify": "^11.0.5",
     "recoil": "^0.7.7"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { store } from './store/redux/store';
 import './styles/index.css';
 import routes from '@/routes';
+import { ToastContainer } from 'react-toastify';
 
 const queryClient = new QueryClient();
 const router = createBrowserRouter(routes);
@@ -16,6 +17,7 @@ function App() {
         <RouterProvider router={router} />
         <ReactQueryDevtools initialIsOpen={false} />
       </Provider>
+      <ToastContainer />
     </QueryClientProvider>
   );
 }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -21,6 +21,7 @@ export const API_ENDPOINTS = {
     DETAIL: '/projects/:projectId',
     UPDATE: '/projects/:projectId',
     DELETE: '/projects/:projectId',
+    RUN_TEST: '/projects/:projectId/run-test',
 
     TESTS: {
       LIST: '/projects/tests',

--- a/src/pages/main/_components/DashboardProjectTable.tsx
+++ b/src/pages/main/_components/DashboardProjectTable.tsx
@@ -34,7 +34,6 @@ const DashboardProjectTable: React.FC<DashboardProjectTableProps> = ({ projects 
   const handleDashboardProjectItem = (item: DashboardProject) => {
     navigate(ROUTES.PROJECT_DETAIL.replace(':projectId', item.projectId.toString()));
   };
-  console.log('projects', projects);
   return (
     <TableItem<DashboardProject>
       columns={columns}

--- a/src/pages/main/_components/DashboardProjectTable.tsx
+++ b/src/pages/main/_components/DashboardProjectTable.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import TableItem from '@/components/ui/table/CustomTable';
 import StatusBadge, { StatusType } from '@/pages/project/_components/StatusBadge';
+import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '@/constants';
 
 interface DashboardProject {
   projectId: number;
@@ -27,20 +29,28 @@ interface DashboardProjectTableProps {
   }>;
 }
 
-const DashboardProjectTable: React.FC<DashboardProjectTableProps> = ({ projects }) => (
-  <TableItem<DashboardProject>
-    columns={columns}
-    items={projects.map((project) => ({
-      ...project,
-      projectStatus: project.projectStatus as StatusType
-    }))}
-    renderCell={(column, item) => {
-      if (column.id === 'projectStatus') {
-        return <StatusBadge status={item.projectStatus} />;
-      }
-      return item[column.id as keyof DashboardProject] ?? '-';
-    }}
-  />
-);
+const DashboardProjectTable: React.FC<DashboardProjectTableProps> = ({ projects }) => {
+  const navigate = useNavigate();
+  const handleDashboardProjectItem = (item: DashboardProject) => {
+    navigate(ROUTES.PROJECT_DETAIL.replace(':projectId', item.projectId.toString()));
+  };
+  console.log('projects', projects);
+  return (
+    <TableItem<DashboardProject>
+      columns={columns}
+      items={projects.map((project) => ({
+        ...project,
+        projectStatus: project.projectStatus as StatusType
+      }))}
+      onItemClick={handleDashboardProjectItem}
+      renderCell={(column, item) => {
+        if (column.id === 'projectStatus') {
+          return <StatusBadge status={item.projectStatus} />;
+        }
+        return item[column.id as keyof DashboardProject] ?? '-';
+      }}
+    />
+  );
+};
 
 export default DashboardProjectTable;

--- a/src/pages/main/_components/DashboardTestTable.tsx
+++ b/src/pages/main/_components/DashboardTestTable.tsx
@@ -3,6 +3,8 @@ import TableItem from '@/components/ui/table/CustomTable';
 import { DashBoardTestList } from '@/types/test.type';
 import StatusBadge from '@/pages/test/_components/StatusBadge';
 import { colors } from '@/styles/theme/colors';
+import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '@/constants';
 
 const columns = [
   { id: 'projectName', label: '프로젝트 명' },
@@ -11,28 +13,37 @@ const columns = [
   { id: 'pageName', label: '페이지 명' }
 ];
 
-const DashboardTestTable: React.FC<{ tests: DashBoardTestList[] }> = ({ tests }) => (
-  <TableItem
-    columns={columns}
-    items={tests}
-    renderCell={(column, item) => {
-      if (column.id === 'testType') {
-        const typeKey = String(item.testType).toUpperCase() as keyof typeof colors.TEST_TYPE_TEXT;
-        return (
-          <span className={`flex items-center font-bold`} style={{ color: colors.TEST_TYPE_TEXT[typeKey] }}>
-            <span
-              className={`w-3 h-3 rounded-sm mr-2`}
-              style={{ backgroundColor: colors.TEST_TYPE_DOT[typeKey] }}></span>
-            {item.testType}
-          </span>
-        );
-      }
-      if (column.id === 'testStatus') {
-        return <StatusBadge status={item.testStatus} />;
-      }
-      return item[column.id as keyof DashBoardTestList] ?? '-';
-    }}
-  />
-);
+const DashboardTestTable: React.FC<{ tests: DashBoardTestList[] }> = ({ tests }) => {
+  const navigate = useNavigate();
+
+  const handleDashboardTestItem = (item: DashBoardTestList) => {
+    navigate(ROUTES.TEST_DETAIL.replace(':projectId', item.projectId.toString()));
+  };
+
+  return (
+    <TableItem
+      columns={columns}
+      items={tests}
+      onItemClick={handleDashboardTestItem}
+      renderCell={(column, item) => {
+        if (column.id === 'testType') {
+          const typeKey = String(item.testType).toUpperCase() as keyof typeof colors.TEST_TYPE_TEXT;
+          return (
+            <span className={`flex items-center font-bold`} style={{ color: colors.TEST_TYPE_TEXT[typeKey] }}>
+              <span
+                className={`w-3 h-3 rounded-sm mr-2`}
+                style={{ backgroundColor: colors.TEST_TYPE_DOT[typeKey] }}></span>
+              {item.testType}
+            </span>
+          );
+        }
+        if (column.id === 'testStatus') {
+          return <StatusBadge status={item.testStatus} />;
+        }
+        return item[column.id as keyof DashBoardTestList] ?? '-';
+      }}
+    />
+  );
+};
 
 export default DashboardTestTable;

--- a/src/pages/project/ProjectCreatePage.tsx
+++ b/src/pages/project/ProjectCreatePage.tsx
@@ -1,90 +1,43 @@
-import { useNavigate } from 'react-router-dom';
-import ProjectCreateForm from '@/pages/project/_components/projectForm/ProjectCreateForm';
-import { useGenerateProject } from '@/store/queries/project/useProjectMutations';
-import { useUserProfile } from '@/store/queries/user/useUserQueries';
-import { GenerateProject } from '@/types/project.type';
 import { ROUTES } from '@/constants';
+import ProjectCreateForm from '@/pages/project/_components/projectForm/ProjectCreateForm';
+import { useProjectForm } from '@/pages/project/_hooks/useCreateProject';
+import { useUserProfile } from '@/store/queries/user/useUserQueries';
+import { useNavigate } from 'react-router-dom';
 
 export default function ProjectCreatePage() {
   const navigate = useNavigate();
-  const { data: userData, isPending, isError } = useUserProfile();
-  const generateProject = useGenerateProject();
+  const { data: userData, isPending: isUserDataLoading, isError: isUserDataError } = useUserProfile();
 
-  const handleGenerateProject = (
-    formData: GenerateProject,
-    actionType: 'register' | 'test',
-    figmaFile: File | null
-  ) => {
-    const data = new FormData();
-
-    // 1. 프로젝트 정보 객체와 actionType을 JSON 문자열로 변환
-    const requestData = {
-      projectName: formData.projectName,
-      expectedTestExecution: formData.expectedTestExecution,
-      projectEnd: formData.projectEnd,
-      description: formData.description,
-      figmaUrl: formData.figmaUrl,
-      serviceUrl: formData.serviceUrl,
-      rootFigmaPage: formData.rootFigmaPage,
-      administrator: userData?.username || undefined, // 사용자 정보가 있으면 추가
-      actionType: actionType // actionType 추가
-    };
-
-    // JSON 데이터를 Blob으로 감싸서 'request' 파트로 추가
-    data.append('request', new Blob([JSON.stringify(requestData)], { type: 'application/json' }), 'request.json');
-
-    // 2. 실제 파일 데이터는 'file' key로 추가
-    if (figmaFile) {
-      data.append('file', figmaFile, figmaFile.name);
+  const handleNavigate = (actionType: 'register' | 'test', projectId?: number) => {
+    if (actionType === 'register') {
+      navigate(ROUTES.PROJECT_DETAIL.replace(':projectId', String(projectId)));
+    } else if (actionType === 'test') {
+      navigate(ROUTES.TESTS);
     }
-
-    // 디버깅을 위한 FormData 내용 로깅
-    console.log('FormData contents:');
-    for (const pair of data.entries()) {
-      console.log(pair[0] + ', ' + (pair[1] instanceof File ? pair[1].name : pair[1]));
-    }
-
-    generateProject.mutate(data, {
-      onSuccess: (response) => {
-        // TODO: alert나 toast로 변경
-        alert(response.message);
-
-        const projectId = response.data?.projectId;
-        if (actionType === 'register') {
-          navigate(ROUTES.PROJECTS);
-        } else if (actionType === 'test' && projectId) {
-          navigate(ROUTES.TESTS); // TODO: 테스트 세부 페이지로 바꿔야됨 일단 테스트용
-        }
-      },
-      onError: () => {
-        alert('필수 입력란을 모두 입력해주세요.');
-      }
-    });
   };
+
+  const { handleProjectSubmit, isLoading } = useProjectForm(userData, handleNavigate);
 
   const handleCancelProject = () => {
-    // TODO: 나중에 현준이가 만든 팝업창으로 바꾸기 우선 confirm()으로 구현
     const isConfirmed = confirm('프로젝트 생성을 취소하시겠습니까?');
     if (isConfirmed) {
-      navigate(ROUTES.HOME); // TODO: 바꿔야할 수도 있음
+      navigate(ROUTES.HOME); // TODO: confirm 부분 나중에 modal로 바꾸기
     }
-    return;
   };
 
-  if (isPending) {
-    return <div>로딩중...</div>;
-  }
-  if (isError) {
-    return <div>프로젝트 관리자명을 불러오는 데 오류가 발생했습니다.</div>;
-  }
-  if (!userData) {
-    return <div>사용자 정보를 찾을 수 없습니다.</div>;
-  }
+  if (isUserDataLoading) return <div className="py-20 text-center">사용자 정보 로딩 중...</div>;
+  if (isUserDataError || !userData)
+    return <div className="py-20 text-center text-red-500">사용자 정보 불러오는 중 오류가 발생했습니다.</div>;
 
   return (
     <div className="w-[90%] m-auto">
       <h1 className="font-bm text-16 text-typography-dark pl-4 pb-8">새 프로젝트 생성</h1>
-      <ProjectCreateForm username={userData.username} onSubmit={handleGenerateProject} onCancel={handleCancelProject} />
+      <ProjectCreateForm
+        username={userData.username}
+        onSubmit={handleProjectSubmit}
+        onCancel={handleCancelProject}
+        isLoading={isLoading}
+      />
     </div>
   );
 }

--- a/src/pages/project/ProjectModifyPage.tsx
+++ b/src/pages/project/ProjectModifyPage.tsx
@@ -1,33 +1,20 @@
+// import ProjectCreateForm from '@/pages/project/_components/projectForm/ProjectCreateForm';
+// import { useGetProjectDetail } from '@/store/queries/project/useProjectQueries';
+// import { useParams } from 'react-router-dom';
+
 export default function ProjectModifyPage() {
+  // const params = useParams();
+  // const projectId = params.projectId;
+  // const { data: projectDetail, isPending, isError } = useGetProjectDetail(Number(projectId));
+
+  // if (isPending) return <div className="py-20 text-center">로딩 중...</div>;
+  // if (isError) return <div className="py-20 text-center text-red-500">오류가 발생했습니다.</div>;
+
   return (
-    <div>
-      프로젝트 수정 페이지Lorem ipsum dolor, sit amet consectetur adipisicing elit. Consequatur, eum? Labore, ducimus
-      ipsa vitae quaerat molestiae ex cupiditate officiis sapiente adipisci et magni sit explicabo perspiciatis
-      aspernatur placeat? Repudiandae, asperiores! 프로젝트 수정 페이지Lorem ipsum dolor, sit amet consectetur
-      adipisicing elit. Consequatur, eum? Labore, ducimus ipsa vitae quaerat molestiae ex cupiditate officiis sapiente
-      adipisci et magni sit explicabo perspiciatis aspernatur placeat? Repudiandae, asperiores! 프로젝트 수정
-      페이지Lorem ipsum dolor, sit amet consectetur adipisicing elit. Consequatur, eum? Labore, ducimus ipsa vitae
-      quaerat molestiae ex cupiditate officiis sapiente adipisci et magni sit explicabo perspiciatis aspernatur placeat?
-      Repudiandae, asperiores! 프로젝트 수정 페이지Lorem ipsum dolor, sit amet consectetur adipisicing elit.
-      Consequatur, eum? Labore, ducimus ipsa vitae quaerat molestiae ex cupiditate officiis sapiente adipisci et magni
-      sit explicabo perspiciatis aspernatur placeat? Repudiandae, asperiores! 프로젝트 수정 페이지Lorem ipsum dolor, sit
-      amet consectetur adipisicing elit. Consequatur, eum? Labore, ducimus ipsa vitae quaerat molestiae ex cupiditate
-      officiis sapiente adipisci et magni sit explicabo perspiciatis aspernatur placeat? Repudiandae, asperiores!
-      프로젝트 수정 페이지Lorem ipsum dolor, sit amet consectetur adipisicing elit. Consequatur, eum? Labore, ducimus
-      ipsa vitae quaerat molestiae ex cupiditate officiis sapiente adipisci et magni sit explicabo perspiciatis
-      aspernatur placeat? Repudiandae, asperiores! 프로젝트 수정 페이지Lorem ipsum dolor, sit amet consectetur
-      adipisicing elit. Consequatur, eum? Labore, ducimus ipsa vitae quaerat molestiae ex cupiditate officiis sapiente
-      adipisci et magni sit explicabo perspiciatis aspernatur placeat? Repudiandae, asperiores! 프로젝트 수정
-      페이지Lorem ipsum dolor, sit amet consectetur adipisicing elit. Consequatur, eum? Labore, ducimus ipsa vitae
-      quaerat molestiae ex cupiditate officiis sapiente adipisci et magni sit explicabo perspiciatis aspernatur placeat?
-      Repudiandae, asperiores! 프로젝트 수정 페이지Lorem ipsum dolor, sit amet consectetur adipisicing elit.
-      Consequatur, eum? Labore, ducimus ipsa vitae quaerat molestiae ex cupiditate officiis sapiente adipisci et magni
-      sit explicabo perspiciatis aspernatur placeat? Repudiandae, asperiores! 프로젝트 수정 페이지Lorem ipsum dolor, sit
-      amet consectetur adipisicing elit. Consequatur, eum? Labore, ducimus ipsa vitae quaerat molestiae ex cupiditate
-      officiis sapiente adipisci et magni sit explicabo perspiciatis aspernatur placeat? Repudiandae, asperiores!
-      프로젝트 수정 페이지Lorem ipsum dolor, sit amet consectetur adipisicing elit. Consequatur, eum? Labore, ducimus
-      ipsa vitae quaerat molestiae ex cupiditate officiis sapiente adipisci et magni sit explicabo perspiciatis
-      aspernatur placeat? Repudiandae, asperiores!
+    <div className="w-[90%] m-auto">
+      {/* <h1 className="font-bm text-16 text-typography-dark pl-4 pb-8">새 프로젝트 생성</h1>
+      <ProjectCreateForm username={userData.username} onSubmit={handleGenerateProject} onCancel={handleCancelProject} /> */}
+      수정페이지임
     </div>
   );
 }

--- a/src/pages/project/_components/projectDetail/ProjectControlButtons.tsx
+++ b/src/pages/project/_components/projectDetail/ProjectControlButtons.tsx
@@ -5,6 +5,7 @@ import { useDeleteProject } from '@/store/queries/project/useProjectMutations';
 import CommonModal from '@/components/modal/CommonModal';
 import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '@/constants';
+import { useRunTest } from '@/store/queries/test/useTestMutations';
 
 interface ProjectControlButtonProps {
   projectId: number;
@@ -14,6 +15,11 @@ export default function ProjectControlButtons({ projectId, projectName }: Projec
   const navigate = useNavigate();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const { mutate: deleteProject } = useDeleteProject();
+  const { mutate: runTestMutation, isPending: isRunningTest, isError: isErrorRunningTest } = useRunTest();
+
+  const handleRunTest = () => {
+    runTestMutation(projectId);
+  };
 
   const handleEditProjectButtonClick = () => {
     navigate(ROUTES.EDIT_PROJECT.replace(':projectId', String(projectId)));
@@ -32,20 +38,31 @@ export default function ProjectControlButtons({ projectId, projectName }: Projec
   const handleCloseDeleteModal = () => {
     setIsDeleteModalOpen(false);
   };
+
+  // TODO: 테스트가 실행중이라는 것을 표현할 다른 방법으로 나중에 대체
+  if (isRunningTest) return <div className="py-20 text-center">테스트 실행 중...</div>;
+  if (isErrorRunningTest) return <div className="py-20 text-center text-red-500">테스트 중 오류가 발생했습니다.</div>;
   return (
     <>
       <section className="flex justify-end gap-3 pt-7">
         <Button
-          text="수정하기"
+          text="프로젝트 수정"
           leftIcon={<PencilIcon />}
           className="flex border-none shadow-custom rounded-10 w-[118px] h-6 items-center justify-center"
           onClick={handleEditProjectButtonClick}
         />
-        <Button
-          text="삭제하기"
-          className="border-none shadow-custom rounded-10 w-[118px] h-6 flex items-center justify-center"
-          onClick={handleProjectDeleteButtonClick}
-        />
+        <div>
+          <Button
+            text={isRunningTest ? '테스트 중' : '테스트 재실행'}
+            onClick={handleRunTest}
+            className="flex border-none shadow-custom rounded-10 w-[118px] h-6 items-center justify-center"
+          />
+          <button
+            className="block mx-auto my-2 border-0 border-b border-[#696969]  text-[#696969] font-medium text-11"
+            onClick={handleProjectDeleteButtonClick}>
+            프로젝트 삭제하기
+          </button>
+        </div>
       </section>
 
       <CommonModal

--- a/src/pages/project/_components/projectDetail/ProjectControlButtons.tsx
+++ b/src/pages/project/_components/projectDetail/ProjectControlButtons.tsx
@@ -58,7 +58,7 @@ export default function ProjectControlButtons({ projectId, projectName }: Projec
             className="flex border-none shadow-custom rounded-10 w-[118px] h-6 items-center justify-center"
           />
           <button
-            className="block mx-auto my-2 border-0 border-b border-[#696969]  text-[#696969] font-medium text-11"
+            className="block mx-auto my-4 border-0 border-b border-[#696969]  text-[#696969] font-medium text-11"
             onClick={handleProjectDeleteButtonClick}>
             프로젝트 삭제하기
           </button>

--- a/src/pages/project/_components/projectDetail/ProjectControlButtons.tsx
+++ b/src/pages/project/_components/projectDetail/ProjectControlButtons.tsx
@@ -6,20 +6,20 @@ import CommonModal from '@/components/modal/CommonModal';
 import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '@/constants';
 import { useRunTest } from '@/store/queries/test/useTestMutations';
+import { toast } from 'react-toastify';
 
 interface ProjectControlButtonProps {
   projectId: number;
   projectName: string;
 }
+
 export default function ProjectControlButtons({ projectId, projectName }: ProjectControlButtonProps) {
   const navigate = useNavigate();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [isRunTestModalOpen, setIsRunTetModalOpen] = useState(false);
+
   const { mutate: deleteProject } = useDeleteProject();
   const { mutate: runTestMutation, isPending: isRunningTest, isError: isErrorRunningTest } = useRunTest();
-
-  const handleRunTest = () => {
-    runTestMutation(projectId);
-  };
 
   const handleEditProjectButtonClick = () => {
     navigate(ROUTES.EDIT_PROJECT.replace(':projectId', String(projectId)));
@@ -39,6 +39,38 @@ export default function ProjectControlButtons({ projectId, projectName }: Projec
     setIsDeleteModalOpen(false);
   };
 
+  const handleRunTestButtonClick = () => {
+    setIsRunTetModalOpen(true);
+  };
+
+  const handleConfirmTestModal = () => {
+    runTestMutation(projectId, {
+      onSuccess: () => {
+        toast.success(
+          <div>
+            테스트 실행이 시작되었습니다.
+            <br />
+            완료까지 몇 분 소요될 수 있습니다.
+          </div>
+        );
+      },
+      onError: () => {
+        toast.error(
+          <div>
+            테스트 실행 요청이 실패했습니다.
+            <br />
+            다시 시도해주세요.
+          </div>
+        );
+      }
+    });
+    setIsRunTetModalOpen(false);
+  };
+
+  const handleCloseTestModal = () => {
+    setIsRunTetModalOpen(false);
+  };
+
   // TODO: 테스트가 실행중이라는 것을 표현할 다른 방법으로 나중에 대체
   if (isRunningTest) return <div className="py-20 text-center">테스트 실행 중...</div>;
   if (isErrorRunningTest) return <div className="py-20 text-center text-red-500">테스트 중 오류가 발생했습니다.</div>;
@@ -54,7 +86,7 @@ export default function ProjectControlButtons({ projectId, projectName }: Projec
         <div>
           <Button
             text={isRunningTest ? '테스트 중' : '테스트 재실행'}
-            onClick={handleRunTest}
+            onClick={handleRunTestButtonClick}
             className="flex border-none shadow-custom rounded-10 w-[118px] h-6 items-center justify-center"
           />
           <button
@@ -72,6 +104,15 @@ export default function ProjectControlButtons({ projectId, projectName }: Projec
         title="프로젝트 삭제"
         cancelText="취소">
         {projectName}를 삭제하시겠습니까? 삭제된 프로젝트는 복구할 수 없습니다.
+      </CommonModal>
+
+      <CommonModal
+        isOpen={isRunTestModalOpen}
+        onClose={handleCloseTestModal}
+        onConfirm={handleConfirmTestModal}
+        title="테스트 실행"
+        cancelText="취소">
+        {projectName}에 대해 테스트를 실행하시겠습니까?
       </CommonModal>
     </>
   );

--- a/src/pages/project/_components/projectForm/ProjectCreateForm.tsx
+++ b/src/pages/project/_components/projectForm/ProjectCreateForm.tsx
@@ -10,9 +10,10 @@ interface ProjectCreateFormPropsType {
   username: string;
   onSubmit: (data: GenerateProject, actionType: 'register' | 'test', figmaFile: File | null) => void;
   onCancel: () => void;
+  isLoading?: boolean;
 }
 
-export default function ProjectCreateForm({ username, onSubmit, onCancel }: ProjectCreateFormPropsType) {
+export default function ProjectCreateForm({ username, onSubmit, onCancel, isLoading }: ProjectCreateFormPropsType) {
   const [formData, setFormData] = useState<GenerateProject>({
     projectName: '',
     expectedTestExecution: '',
@@ -92,14 +93,21 @@ export default function ProjectCreateForm({ username, onSubmit, onCancel }: Proj
         />
 
         <div className="flex justify-center gap-10 children:px-8 children:font-medium">
-          <Button text="등록" type="button" data-submit-type="register" onClick={handleRegisterProject} />
           <Button
-            text="등록 후 테스트 생성하기"
+            text={isLoading ? '등록 중...' : '등록'}
+            type="button"
+            data-submit-type="register"
+            onClick={handleRegisterProject}
+            disabled={isLoading}
+          />
+          <Button
+            text={isLoading ? '등록 및 테스트 중...' : '등록 후 테스트 생성하기'}
             type="button"
             data-submit-type="test after register"
             onClick={handleRegisterAndTest}
+            disabled={isLoading}
           />
-          <Button text="취소" type="button" data-submit-type="cancel" onClick={onCancel} />
+          <Button text="취소" type="button" data-submit-type="cancel" onClick={onCancel} disabled={isLoading} />
         </div>
       </section>
     </form>

--- a/src/pages/project/_hooks/useCreateProject.ts
+++ b/src/pages/project/_hooks/useCreateProject.ts
@@ -1,0 +1,61 @@
+import { useGenerateProject } from '@/store/queries/project/useProjectMutations';
+import { useRunTest } from '@/store/queries/test/useTestMutations';
+import { GenerateProject } from '@/types/project.type';
+import { toast } from 'react-toastify';
+
+export const useProjectForm = (
+  userData: GenerateProject,
+  onNavigate: (actionType: 'register' | 'test', projectId?: number) => void
+) => {
+  const generateProject = useGenerateProject();
+  const runTest = useRunTest();
+
+  const createFormData = (formData: GenerateProject, actionType: 'register' | 'test', figmaFile: File | null) => {
+    const data = new FormData();
+
+    const requestData = {
+      projectName: formData.projectName,
+      expectedTestExecution: formData.expectedTestExecution,
+      projectEnd: formData.projectEnd,
+      description: formData.description,
+      figmaUrl: formData.figmaUrl,
+      serviceUrl: formData.serviceUrl,
+      rootFigmaPage: formData.rootFigmaPage,
+      administrator: userData?.administrator || undefined,
+      actionType: actionType
+    };
+
+    data.append('request', new Blob([JSON.stringify(requestData)], { type: 'application/json' }), 'request.json');
+
+    if (figmaFile) {
+      data.append('file', figmaFile, figmaFile.name);
+    }
+
+    return data;
+  };
+
+  const handleProjectSubmit = (formData: GenerateProject, actionType: 'register' | 'test', figmaFile: File | null) => {
+    const data = createFormData(formData, actionType, figmaFile);
+
+    generateProject.mutate(data, {
+      onSuccess: (response) => {
+        toast.success(response.message);
+        const projectId = response.data?.projectId;
+
+        if (actionType === 'test' && projectId) {
+          runTest.mutate(projectId);
+        }
+
+        onNavigate(actionType, projectId);
+      },
+      onError: () => {
+        alert('필수 입력란을 모두 입력해주세요.');
+      }
+    });
+  };
+
+  return {
+    handleProjectSubmit,
+    isLoading: generateProject.isPending || runTest.isPending
+  };
+};

--- a/src/pages/test/_components/testDetail/page-issue/IssueContents.tsx
+++ b/src/pages/test/_components/testDetail/page-issue/IssueContents.tsx
@@ -70,10 +70,13 @@ export default function IssueContents({ issueData, tabMeta }: IssueContentsProps
       <div className="border-[1.5px] border-[#0000FF] rounded-[15px] bg-[#0000FF]/10 py-[22px] px-6 space-y-2">
         <p className="font-bold text-14 text-typography-dark">해결 제안</p>
         <p className="font-medium text-11 text-typography-dark">
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Repudiandae animi, in esse aliquam tenetur ducimus
-          delectus nemo sapiente quos, dolor ea asperiores! Fugiat velit ipsam distinctio id dicta repellendus beatae.
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Repudiandae animi, in esse aliquam tenetur ducimus
-          delectus nemo sapiente quos, dolor ea asperiores! Fugiat velit ipsam distinctio id dicta repellendus beatae.
+          요소 클릭 시 예상된 경로(/dashboard)로 이동하지 않고 /error 페이지로 리디렉션되었습니다. 버튼 혹은 링크에
+          연결된 라우팅 설정이 올바르지 않거나, 조건문 내부 로직에서 예외가 발생했을 가능성이 있습니다. 먼저 해당 트리거
+          요소의 클릭 이벤트 핸들러 또는 라우터 설정을 점검해보시기 바랍니다. <br />
+          <br />
+          또한, 접근 권한이나 로그인 세션 등의 조건에 따라 /dashboard로의 이동이 차단되었는지도 확인이 필요합니다.
+          페이지 이동 시점의 콘솔 로그와 네트워크 응답을 함께 점검하면 문제 원인을 식별할 수 있습니다. 불일치가
+          반복된다면, 테스트 대상 요소의 selector 또는 조건 분기 로직을 리팩터링하는 것이 권장됩니다.
         </p>
       </div>
     </div>

--- a/src/store/queries/test/useTestMutations.ts
+++ b/src/store/queries/test/useTestMutations.ts
@@ -1,1 +1,22 @@
+import { API_ENDPOINTS } from '@/constants';
+import axiosInstance from '@/services/api/axios';
+import { useMutation } from '@tanstack/react-query';
+
 // test 관련 post, put, delete 등의 api
+export const useRunTest = () => {
+  return useMutation({
+    mutationFn: async (projectId: number) => {
+      const response = await axiosInstance.post(
+        API_ENDPOINTS.PROJECTS.RUN_TEST.replace(':projectId', String(projectId)),
+        {},
+        {
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded'
+          }
+        }
+      );
+
+      return response.data;
+    }
+  });
+};

--- a/src/types/dashboard.type.ts
+++ b/src/types/dashboard.type.ts
@@ -14,6 +14,7 @@ export interface DashboardHomeResponse {
     }>;
     tests: Array<{
       testId: number;
+      projectId: number;
       projectName: string;
       pageName: string;
       testType: string;

--- a/src/types/test.type.ts
+++ b/src/types/test.type.ts
@@ -12,6 +12,7 @@ export interface TestData {
 
 export interface DashBoardTestList {
   testId: number;
+  projectId: number;
   projectName: string;
   pageName: string;
   testType: string;


### PR DESCRIPTION
## 🛰️ Issue Number
이슈번호: #69

## 🪐 작업 내용

<작업 사진>
<img width="914" alt="image" src="https://github.com/user-attachments/assets/c8122280-cda8-43c4-b6ef-fd72d5bb4e02" />
<img width="240" alt="image" src="https://github.com/user-attachments/assets/05778341-b90e-40ed-878f-f9593884777d" />
<img width="292" alt="image" src="https://github.com/user-attachments/assets/8e0d9780-de07-4782-abbb-78263f73426f" />


<커밋 설명>
- 백엔드 요청대로 테스트 세부 페이지에 mockData 추가
- 페이지 테스트 실행 api mutation 함수 정의
- 프로젝트 세부 페이지 테스트 재실행 버튼 추가
- 대시보드 프로젝트, 테스트 세부 페이지로 라우팅
- 테스트 실행 api 요청 시, 확인 modal, 성공 여부 toast 컴포넌트 구현
- 테스트 생성 페이지에서 "등록 후 테스트" 버튼 클릭 시, 프로젝트 생성 후 테스트 api 요청

<전달 사항>
- react-toastify 라이브러리를 설치했기 때문에 pull 하시면 npm i 한번 해주세요!
- "등록 후 테스트" 버튼 기능 구현할 때 프로젝트 등록 요청이 성공적으로 실행됐을 때 테스트 실행 api 요청을 보내야 했는데 props로 onSubmit 함수만 받아와서 따로 커스텀이 어려워 테스트 생성하는 로직을 projects 폴더 내에 _hooks 폴더 생성 해 로직 분리하여 재사용하였습니다. 


## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
- [ ] 코드 스타일을 eslint/prettier로 맞췄나요?