### PR TITLE
[ #81 | Refactor ] 지연 로딩 적용, projectStatus에 따른 UI 처리

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="./src/assets/images/AUTA_small.svg" />
+    <link rel="icon" type="image/svg+xml" href="/src/assets/logos/AUTA_small.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>피그마기반 UI 테스트 자동화 플랫폼</title>
   </head>

--- a/src/components/layout/page-layout/Layout.tsx
+++ b/src/components/layout/page-layout/Layout.tsx
@@ -4,7 +4,8 @@ import Sidebar from '@/components/layout/sidebar/Sidebar';
 import { ROUTES } from '@/constants';
 import { useAppSelector } from '@/store/redux/store';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
+import PageLoader from '@/components/ui/loader/PageLoader';
 
 export default function Layout() {
   const location = useLocation();
@@ -67,7 +68,9 @@ export default function Layout() {
         <div className="w-full">
           {!shouldHideSidebarAndHeader && <Header onMenuClick={() => setSidebarOpen((prev) => !prev)} />}
           <main className="flex-grow py-4 pt-[90px] lg:pt-0 max-md:pt-28">
-            <Outlet />
+            <Suspense fallback={<PageLoader />}>
+              <Outlet />
+            </Suspense>
           </main>
         </div>
         <Footer />

--- a/src/components/ui/button/Button.tsx
+++ b/src/components/ui/button/Button.tsx
@@ -19,22 +19,20 @@ export default function Button({
   ...props
 }: ButtonProps) {
   const baseClasses = `
-    rounded-10
-    text-11
-    text-typography-dark
-    transition-colors
-    border border-button-border
-    bg-button-default
-    hover:bg-button-hover
-    active:bg-button-press
-    disabled:opacity-50
-    disabled:cursor-not-allowed
-    flex
-    justify-center
-    items-center
-    py-2 
-    px-4
-  `;
+  rounded-10
+  text-11
+  text-typography-dark
+  transition-colors
+  border border-button-border
+  ${className?.includes('bg-') ? '' : 'bg-button-default hover:bg-button-hover active:bg-button-press'}
+  disabled:opacity-50
+  disabled:cursor-not-allowed
+  flex
+  justify-center
+  items-center
+  py-2 
+  px-4
+`;
 
   const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (disabled) return;

--- a/src/components/ui/loader/PageLoader.tsx
+++ b/src/components/ui/loader/PageLoader.tsx
@@ -1,0 +1,9 @@
+import { BeatLoader } from 'react-spinners';
+
+export default function PageLoader() {
+  return (
+    <div className="flex justify-center items-center h-screen">
+      <BeatLoader color="#B3C7AA" />
+    </div>
+  );
+}

--- a/src/pages/main/DashboardPage.tsx
+++ b/src/pages/main/DashboardPage.tsx
@@ -5,17 +5,12 @@ import OverviewSection from './_components/OverviewSection';
 import DashboardProjectTable from './_components/DashboardProjectTable';
 import DashboardTestTable from './_components/DashboardTestTable';
 import { useDashboardHome } from '@/store/queries/dashboard/useDashboardHomeQuery';
-import BeatLoader from 'react-spinners/BeatLoader';
+import PageLoader from '@/components/ui/loader/PageLoader';
 
 export default function DashboardPage() {
   const { data, isPending, isError } = useDashboardHome();
 
-  if (isPending)
-    return (
-      <div className="flex justify-center items-center h-screen">
-        <BeatLoader color="#B3C7AA" />
-      </div>
-    );
+  if (isPending) return <PageLoader />;
   if (isError) return <div className="py-20 text-center text-red-500">오류가 발생했습니다.</div>;
 
   return (

--- a/src/pages/main/DashboardPage.tsx
+++ b/src/pages/main/DashboardPage.tsx
@@ -5,11 +5,17 @@ import OverviewSection from './_components/OverviewSection';
 import DashboardProjectTable from './_components/DashboardProjectTable';
 import DashboardTestTable from './_components/DashboardTestTable';
 import { useDashboardHome } from '@/store/queries/dashboard/useDashboardHomeQuery';
+import BeatLoader from 'react-spinners/BeatLoader';
 
 export default function DashboardPage() {
   const { data, isPending, isError } = useDashboardHome();
 
-  if (isPending) return <div className="py-20 text-center">로딩 중...</div>;
+  if (isPending)
+    return (
+      <div className="flex justify-center items-center h-screen">
+        <BeatLoader color="#B3C7AA" />
+      </div>
+    );
   if (isError) return <div className="py-20 text-center text-red-500">오류가 발생했습니다.</div>;
 
   return (

--- a/src/pages/project/ProjectCreatePage.tsx
+++ b/src/pages/project/ProjectCreatePage.tsx
@@ -1,7 +1,7 @@
 import CommonModal from '@/components/modal/CommonModal';
+import PageLoader from '@/components/ui/loader/PageLoader';
 import ProjectCreateForm from '@/pages/project/_components/projectForm/ProjectCreateForm';
 import { useProjectFormHandler } from '@/pages/project/_hooks/useProjectFormHandler';
-import { BeatLoader } from 'react-spinners';
 
 export default function ProjectCreatePage() {
   const {
@@ -19,12 +19,7 @@ export default function ProjectCreatePage() {
     mode: 'create'
   });
 
-  if (isPending)
-    return (
-      <div className="flex justify-center items-center h-screen">
-        <BeatLoader color="#B3C7AA" />
-      </div>
-    );
+  if (isPending) return <PageLoader />;
   if (isError || !username)
     return <div className="py-20 text-center text-red-500">사용자 정보 불러오는 중 오류가 발생했습니다.</div>;
 

--- a/src/pages/project/ProjectCreatePage.tsx
+++ b/src/pages/project/ProjectCreatePage.tsx
@@ -1,6 +1,7 @@
 import CommonModal from '@/components/modal/CommonModal';
 import ProjectCreateForm from '@/pages/project/_components/projectForm/ProjectCreateForm';
 import { useProjectFormHandler } from '@/pages/project/_hooks/useProjectFormHandler';
+import { BeatLoader } from 'react-spinners';
 
 export default function ProjectCreatePage() {
   const {
@@ -18,7 +19,12 @@ export default function ProjectCreatePage() {
     mode: 'create'
   });
 
-  if (isPending) return <div className="py-20 text-center">사용자 정보 로딩 중...</div>;
+  if (isPending)
+    return (
+      <div className="flex justify-center items-center h-screen">
+        <BeatLoader color="#B3C7AA" />
+      </div>
+    );
   if (isError || !username)
     return <div className="py-20 text-center text-red-500">사용자 정보 불러오는 중 오류가 발생했습니다.</div>;
 

--- a/src/pages/project/ProjectDetailPage.tsx
+++ b/src/pages/project/ProjectDetailPage.tsx
@@ -7,13 +7,19 @@ import ReportBrief from '@/pages/project/_components/projectDetail/ReportBrief';
 import ProjectControlButtons from '@/pages/project/_components/projectDetail/ProjectControlButtons';
 import ProjectPageTable from '@/pages/project/_components/projectDetail/ProjectPageTable';
 import ProjectSummaryGraph from '@/pages/project/_components/projectDetail/ProjectSummaryGraph';
+import BeatLoader from 'react-spinners/BeatLoader';
 
 export default function ProjectDetailPage() {
   const params = useParams();
   const projectId = params.projectId;
   const { data: projectDetail, isPending, isError } = useGetProjectDetail(Number(projectId));
 
-  if (isPending) return <div className="py-20 text-center">로딩 중...</div>;
+  if (isPending)
+    return (
+      <div className="flex justify-center items-center h-screen">
+        <BeatLoader color="#B3C7AA" />
+      </div>
+    );
   if (isError) return <div className="py-20 text-center text-red-500">오류가 발생했습니다.</div>;
 
   const projectBasicInfo = {

--- a/src/pages/project/ProjectDetailPage.tsx
+++ b/src/pages/project/ProjectDetailPage.tsx
@@ -1,18 +1,23 @@
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import BeatLoader from 'react-spinners/BeatLoader';
 import { useGetProjectDetail } from '@/store/queries/project/useProjectQueries';
+import { useRunTest } from '@/store/queries/test/useTestMutations';
+import CommonModal from '@/components/modal/CommonModal';
 import DesignSourceSection from '@/pages/project/_components/projectForm/DesignSourceSection';
 import ProjectTitle from '@/pages/project/_components/ProjectTitle';
 import ProjectInfo from '@/pages/project/_components/projectDetail/ProjectInfo';
 import ReportBrief from '@/pages/project/_components/projectDetail/ReportBrief';
 import ProjectControlButtons from '@/pages/project/_components/projectDetail/ProjectControlButtons';
-import ProjectPageTable from '@/pages/project/_components/projectDetail/ProjectPageTable';
-import ProjectSummaryGraph from '@/pages/project/_components/projectDetail/ProjectSummaryGraph';
-import BeatLoader from 'react-spinners/BeatLoader';
-
+import NotStartedState from '@/pages/project/_components/projectDetail/NotStartedState';
+import InProgressState from '@/pages/project/_components/projectDetail/InProgressState';
+import CompletedState from '@/pages/project/_components/projectDetail/CompletedState';
 export default function ProjectDetailPage() {
-  const params = useParams();
-  const projectId = params.projectId;
+  const { projectId } = useParams();
   const { data: projectDetail, isPending, isError } = useGetProjectDetail(Number(projectId));
+  const { mutate: runTestMutation, isPending: isRunningTest } = useRunTest();
+  const [isRunTestModalOpen, setIsRunTestModalOpen] = useState(false);
 
   if (isPending)
     return (
@@ -31,6 +36,42 @@ export default function ProjectDetailPage() {
     testExecutionTime: projectDetail?.testExecutionTime
   };
 
+  const handleRunTest = () => {
+    runTestMutation(Number(projectId), {
+      onSuccess: () => {
+        toast.success('테스트 실행이 시작되었습니다.\n완료까지 몇 분 소요될 수 있습니다.');
+      },
+      onError: () => {
+        toast.error('테스트 실행 요청이 실패했습니다.\n다시 시도해주세요.');
+      }
+    });
+    setIsRunTestModalOpen(false);
+  };
+
+  const handleOpenTestModal = () => {
+    setIsRunTestModalOpen(true);
+  };
+
+  const handleCloseTestModal = () => {
+    setIsRunTestModalOpen(false);
+  };
+
+  // projectStatus별 렌더링 함수
+  const renderProjectStatusSection = () => {
+    const status = projectDetail?.projectStatus;
+
+    switch (status) {
+      case 'NOT_STARTED':
+        return <NotStartedState onOpenTestModal={handleOpenTestModal} isRunningTest={isRunningTest} />;
+      case 'IN_PROGRESS':
+        return <InProgressState />;
+      case 'COMPLETED':
+        return <CompletedState projectDetail={projectDetail} />;
+      default:
+        return <NotStartedState onOpenTestModal={handleOpenTestModal} isRunningTest={isRunningTest} />;
+    }
+  };
+
   return (
     <div className="w-[90%] flex flex-col m-auto">
       <ProjectTitle />
@@ -38,11 +79,12 @@ export default function ProjectDetailPage() {
       <span className="border border-typography-gray my-4"></span>
 
       <section className="flex gap-6 justify-center py-4 children:shadow-custom children:rounded-15 children:w-full">
-        <ProjectSummaryGraph testSummary={projectDetail?.testSummary} />
-        <ProjectPageTable pages={projectDetail?.pages || []} />
+        {renderProjectStatusSection()}
       </section>
 
-      <ReportBrief reportSummary={projectDetail?.reportSummary} projectId={Number(projectId)} />
+      {projectDetail?.projectStatus === 'COMPLETED' && (
+        <ReportBrief reportSummary={projectDetail?.reportSummary} projectId={Number(projectId)} />
+      )}
 
       <DesignSourceSection
         figmaUrl={projectDetail?.figmaUrl}
@@ -53,7 +95,21 @@ export default function ProjectDetailPage() {
         disabled
       />
 
-      <ProjectControlButtons projectId={Number(projectId)} projectName={projectBasicInfo.projectName} />
+      <ProjectControlButtons
+        projectId={Number(projectId)}
+        projectName={projectBasicInfo.projectName}
+        projectStatus={projectDetail?.projectStatus}
+        onOpenTestModal={handleOpenTestModal}
+      />
+
+      <CommonModal
+        isOpen={isRunTestModalOpen}
+        onClose={handleCloseTestModal}
+        onConfirm={handleRunTest}
+        title="테스트 실행"
+        cancelText="취소">
+        {projectDetail?.projectName}에 대해 테스트를 실행하시겠습니까?
+      </CommonModal>
     </div>
   );
 }

--- a/src/pages/project/ProjectDetailPage.tsx
+++ b/src/pages/project/ProjectDetailPage.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
-import BeatLoader from 'react-spinners/BeatLoader';
 import { useGetProjectDetail } from '@/store/queries/project/useProjectQueries';
 import { useRunTest } from '@/store/queries/test/useTestMutations';
 import CommonModal from '@/components/modal/CommonModal';
@@ -13,18 +12,14 @@ import ProjectControlButtons from '@/pages/project/_components/projectDetail/Pro
 import NotStartedState from '@/pages/project/_components/projectDetail/NotStartedState';
 import InProgressState from '@/pages/project/_components/projectDetail/InProgressState';
 import CompletedState from '@/pages/project/_components/projectDetail/CompletedState';
+import PageLoader from '@/components/ui/loader/PageLoader';
 export default function ProjectDetailPage() {
   const { projectId } = useParams();
   const { data: projectDetail, isPending, isError } = useGetProjectDetail(Number(projectId));
   const { mutate: runTestMutation, isPending: isRunningTest } = useRunTest();
   const [isRunTestModalOpen, setIsRunTestModalOpen] = useState(false);
 
-  if (isPending)
-    return (
-      <div className="flex justify-center items-center h-screen">
-        <BeatLoader color="#B3C7AA" />
-      </div>
-    );
+  if (isPending) return <PageLoader />;
   if (isError) return <div className="py-20 text-center text-red-500">오류가 발생했습니다.</div>;
 
   const projectBasicInfo = {

--- a/src/pages/project/ProjectMangePage.tsx
+++ b/src/pages/project/ProjectMangePage.tsx
@@ -7,9 +7,9 @@ import { useGetProjectList } from '@/store/queries/project/useProjectQueries';
 import { ProjectListData } from '@/types/project.type';
 import { useSelector } from 'react-redux';
 import { RootState } from '@/store/redux/store';
-import { BeatLoader } from 'react-spinners';
 import TableListCard from '@/pages/project/_components/responsive_tableListCard/TableListCard';
 import ScrollToTopButton from '@/components/ui/scrollTopButton/ScrollToTopButton';
+import PageLoader from '@/components/ui/loader/PageLoader';
 
 const columns = [
   { id: 'projectName', label: '프로젝트 명' },
@@ -38,12 +38,7 @@ export default function ProjectMangePage() {
     navigate(ROUTES.PROJECT_DETAIL.replace(':projectId', item.projectId.toString()));
   };
 
-  if (isPending)
-    return (
-      <div className="flex justify-center items-center h-screen">
-        <BeatLoader color="#B3C7AA" />
-      </div>
-    );
+  if (isPending) return <PageLoader />;
   if (isError) return <div>오류가 발생했습니다.</div>;
 
   return (

--- a/src/pages/project/ProjectModifyPage.tsx
+++ b/src/pages/project/ProjectModifyPage.tsx
@@ -1,7 +1,7 @@
 import CommonModal from '@/components/modal/CommonModal';
+import PageLoader from '@/components/ui/loader/PageLoader';
 import ProjectCreateForm from '@/pages/project/_components/projectForm/ProjectCreateForm';
 import { useProjectFormHandler } from '@/pages/project/_hooks/useProjectFormHandler';
-import { BeatLoader } from 'react-spinners';
 
 export default function ProjectModifyPage() {
   const {
@@ -18,12 +18,7 @@ export default function ProjectModifyPage() {
     mode: 'modify'
   });
 
-  if (isPending)
-    return (
-      <div className="py-20 text-center">
-        <BeatLoader color="#B3C7AA" size={15} />
-      </div>
-    );
+  if (isPending) return <PageLoader />;
   if (isError) return <div className="py-20 text-center text-red-500">오류가 발생했습니다.</div>;
 
   return (

--- a/src/pages/project/_components/projectDetail/CompletedState.tsx
+++ b/src/pages/project/_components/projectDetail/CompletedState.tsx
@@ -1,0 +1,15 @@
+import ProjectPageTable from '@/pages/project/_components/projectDetail/ProjectPageTable';
+import ProjectSummaryGraph from '@/pages/project/_components/projectDetail/ProjectSummaryGraph';
+import { ProjectDetailData } from '@/types/project.type';
+
+interface CompleteStateProps {
+  projectDetail: ProjectDetailData;
+}
+export default function CompletedState({ projectDetail }: CompleteStateProps) {
+  return (
+    <div>
+      {projectDetail.testSummary && <ProjectSummaryGraph testSummary={projectDetail.testSummary} />}
+      <ProjectPageTable pages={projectDetail?.pages || []} />
+    </div>
+  );
+}

--- a/src/pages/project/_components/projectDetail/InProgressState.tsx
+++ b/src/pages/project/_components/projectDetail/InProgressState.tsx
@@ -1,0 +1,16 @@
+import RingLoader from 'react-spinners/RingLoader';
+
+export default function InProgressState() {
+  return (
+    <div className="shadow-custom rounded-15 p-6 w-full bg-transparent">
+      <div className="flex flex-col items-center justify-center h-64 space-y-6">
+        <RingLoader color="#B3C7AA" size={80} />
+
+        <div className="text-center space-y-2">
+          <h3 className="text-xl font-bold text-typography-dark">테스트 진행 중</h3>
+          <p className="text-typography-gray">완료까지 몇 분 소요될 수 있습니다.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/project/_components/projectDetail/NotStartedState.tsx
+++ b/src/pages/project/_components/projectDetail/NotStartedState.tsx
@@ -1,0 +1,28 @@
+import Button from '@/components/ui/button/Button';
+
+interface NotStartedStateProps {
+  onOpenTestModal: () => void; // 모달만 열기
+  isRunningTest?: boolean;
+}
+
+export default function NotStartedState({ onOpenTestModal, isRunningTest = false }: NotStartedStateProps) {
+  return (
+    <div className="shadow-custom rounded-15 p-6 w-full">
+      <div className="flex flex-col items-center justify-center h-64 bg-gray-50 rounded-xl border-2 border-dashed border-gray-300 gap-4">
+        <div className="flex flex-col gap-3 items-center">
+          <p className="text-typography-gray">프로젝트 설정이 완료되었습니다.</p>
+          <p className="text-blue-600 font-medium">지금 바로 자동화 테스트를 시작해보세요! 🚀</p>
+        </div>
+
+        <div className="pt-2">
+          <Button
+            text={isRunningTest ? '테스트 시작 중...' : '테스트 시작하기'}
+            onClick={onOpenTestModal}
+            disabled={isRunningTest}
+            className="w-96 text-16 border-none bg-blue-500 text-white hover:bg-blue-600 active:bg-blue-700 disabled:opacity-50"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/project/_components/projectDetail/ProjectControlButtons.tsx
+++ b/src/pages/project/_components/projectDetail/ProjectControlButtons.tsx
@@ -5,21 +5,25 @@ import { useDeleteProject } from '@/store/queries/project/useProjectMutations';
 import CommonModal from '@/components/modal/CommonModal';
 import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '@/constants';
-import { useRunTest } from '@/store/queries/test/useTestMutations';
-import { toast } from 'react-toastify';
 
 interface ProjectControlButtonProps {
   projectId: number;
   projectName: string;
+  projectStatus: string;
+  onOpenTestModal: () => void;
+  isRunningTest?: boolean;
 }
 
-export default function ProjectControlButtons({ projectId, projectName }: ProjectControlButtonProps) {
+export default function ProjectControlButtons({
+  projectId,
+  projectName,
+  projectStatus,
+  onOpenTestModal,
+  isRunningTest = false
+}: ProjectControlButtonProps) {
   const navigate = useNavigate();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const [isRunTestModalOpen, setIsRunTetModalOpen] = useState(false);
-
   const { mutate: deleteProject } = useDeleteProject();
-  const { mutate: runTestMutation, isPending: isRunningTest, isError: isErrorRunningTest } = useRunTest();
 
   const handleEditProjectButtonClick = () => {
     navigate(ROUTES.EDIT_PROJECT.replace(':projectId', String(projectId)));
@@ -39,58 +43,30 @@ export default function ProjectControlButtons({ projectId, projectName }: Projec
     setIsDeleteModalOpen(false);
   };
 
-  const handleRunTestButtonClick = () => {
-    setIsRunTetModalOpen(true);
-  };
-
-  const handleConfirmTestModal = () => {
-    runTestMutation(projectId, {
-      onSuccess: () => {
-        toast.success(
-          <div>
-            테스트 실행이 시작되었습니다.
-            <br />
-            완료까지 몇 분 소요될 수 있습니다.
-          </div>
-        );
-      },
-      onError: () => {
-        toast.error(
-          <div>
-            테스트 실행 요청이 실패했습니다.
-            <br />
-            다시 시도해주세요.
-          </div>
-        );
-      }
-    });
-    setIsRunTetModalOpen(false);
-  };
-
-  const handleCloseTestModal = () => {
-    setIsRunTetModalOpen(false);
-  };
-
-  // TODO: 테스트가 실행중이라는 것을 표현할 다른 방법으로 나중에 대체
-  if (isRunningTest) return <div className="py-20 text-center">테스트 실행 중...</div>;
-  if (isErrorRunningTest) return <div className="py-20 text-center text-red-500">테스트 중 오류가 발생했습니다.</div>;
   return (
     <>
-      <section className="flex justify-end gap-3 pt-7">
-        <Button
-          text="프로젝트 수정"
-          leftIcon={<PencilIcon />}
-          className="flex border-none shadow-custom rounded-10 w-[118px] h-6 items-center justify-center"
-          onClick={handleEditProjectButtonClick}
-        />
-        <div>
+      <section className="pt-7">
+        <div className="flex justify-end gap-3 mb-4">
           <Button
-            text={isRunningTest ? '테스트 중' : '테스트 재실행'}
-            onClick={handleRunTestButtonClick}
+            text="프로젝트 수정"
+            leftIcon={<PencilIcon />}
             className="flex border-none shadow-custom rounded-10 w-[118px] h-6 items-center justify-center"
+            onClick={handleEditProjectButtonClick}
           />
+
+          {projectStatus === 'COMPLETED' && (
+            <Button
+              text={isRunningTest ? '테스트 중' : '테스트 재실행'}
+              onClick={onOpenTestModal}
+              disabled={isRunningTest}
+              className="flex border-none shadow-custom rounded-10 w-[118px] h-6 items-center justify-center"
+            />
+          )}
+        </div>
+
+        <div className="flex justify-end">
           <button
-            className="block mx-auto my-4 border-0 border-b border-[#696969]  text-[#696969] font-medium text-11"
+            className="border-0 border-b border-[#696969] text-[#696969] font-medium text-11 hover:text-gray-800 transition-colors"
             onClick={handleProjectDeleteButtonClick}>
             프로젝트 삭제하기
           </button>
@@ -104,15 +80,6 @@ export default function ProjectControlButtons({ projectId, projectName }: Projec
         title="프로젝트 삭제"
         cancelText="취소">
         {projectName}를 삭제하시겠습니까? 삭제된 프로젝트는 복구할 수 없습니다.
-      </CommonModal>
-
-      <CommonModal
-        isOpen={isRunTestModalOpen}
-        onClose={handleCloseTestModal}
-        onConfirm={handleConfirmTestModal}
-        title="테스트 실행"
-        cancelText="취소">
-        {projectName}에 대해 테스트를 실행하시겠습니까?
       </CommonModal>
     </>
   );

--- a/src/pages/project/_components/projectDetail/ProjectPageTable.tsx
+++ b/src/pages/project/_components/projectDetail/ProjectPageTable.tsx
@@ -9,25 +9,19 @@ export default function ProjectPageTable({ pages = [] }: ProjectPageTableProps) 
   return (
     <div className="p-6 basis-1/3 w-full">
       <div className="overflow-y-auto h-full">
-        <table className="w-full text-center">
+        <table className="w-full text-center table-fixed">
           <thead>
             <tr className="text-14 text-typography-dark font-bold border-b border-b-[#CCCCCC]">
-              <th className="py-2 w-full min-w-0 max-w-full overflow-hidden truncate whitespace-nowrap">페이지명</th>
-              <th className="py-2 w-full min-w-0 max-w-full overflow-hidden truncate whitespace-nowrap">페이지 URL</th>
+              <th className="py-2 w-1/2 overflow-hidden truncate whitespace-nowrap">페이지명</th>
+              <th className="py-2 w-1/2 overflow-hidden truncate whitespace-nowrap">페이지 URL</th>
             </tr>
           </thead>
           <tbody>
             {pages.length > 0 ? (
               pages.map((page, index) => (
                 <tr key={index} className="children:font-medium text-11 text-typography-dark">
-                  <td className="py-2 w-full min-w-0 max-w-full overflow-hidden truncate whitespace-nowrap">
-                    {page.pageName}
-                  </td>
-                  <td className="py-2 w-full min-w-0 max-w-full overflow-hidden truncate whitespace-nowrap">
-                    <p className="w-full min-w-0 max-w-full overflow-hidden truncate whitespace-nowrap">
-                      {page.pageBaseUrl}
-                    </p>
-                  </td>
+                  <td className="py-2 w-1/2 overflow-hidden truncate whitespace-nowrap">{page.pageName}</td>
+                  <td className="py-2 w-1/2 overflow-hidden truncate whitespace-nowrap">{page.pageBaseUrl}</td>
                 </tr>
               ))
             ) : (

--- a/src/pages/project/_components/projectDetail/ReportBrief.tsx
+++ b/src/pages/project/_components/projectDetail/ReportBrief.tsx
@@ -16,16 +16,13 @@ export default function ReportBrief({ reportSummary, projectId }: ReportBriefPro
         <Button
           text="테스트 리포트 바로가기"
           className={`border-none shadow-custom h-6`}
-          onClick={() => navigate(ROUTES.EDIT_PROJECT.replace(':projectId', String(projectId)))}
-          disabled={reportSummary === null}
+          onClick={() => navigate(ROUTES.TEST_DETAIL.replace(':projectId', String(projectId)))}
         />
       </div>
       {reportSummary === null ? (
         <div className="shadow-custom rounded-15 p-4 font-medium text-11 text-typography-dark">
           <div className="border border-dashed border-typography-gray p-4 rounded-md w-full min-h-[200px] h-full flex justify-center items-center">
-            <p className="font-medium text-16 text-typography-gray">
-              아직 생성된 리포트가 없습니다. 테스트를 먼저 실행해보세요.
-            </p>
+            <p className="font-medium text-16 text-typography-gray">준비 중인 기능입니다. 조금만 기다려주세요🚀</p>
           </div>
         </div>
       ) : (

--- a/src/pages/test/TestDetailPage.tsx
+++ b/src/pages/test/TestDetailPage.tsx
@@ -4,13 +4,19 @@ import ProjectInfo from '@/pages/project/_components/projectDetail/ProjectInfo';
 import TestTitle from '@/pages/test/_components/TestTitle';
 import TestRatingBars from '@/pages/test/_components/testDetail/TestRatingBars';
 import PageIssueSection from '@/pages/test/_components/testDetail/page-issue';
+import BeatLoader from 'react-spinners/BeatLoader';
 
 export default function TestDetailPage() {
   const params = useParams();
   const projectId = params.projectId;
   const { data: testDetail, isPending, isError } = useGetTestDetail(Number(projectId));
 
-  if (isPending) return <div className="py-20 text-center">로딩 중...</div>;
+  if (isPending)
+    return (
+      <div className="flex justify-center items-center h-screen">
+        <BeatLoader color="#B3C7AA" />
+      </div>
+    );
   if (isError) return <div className="py-20 text-center text-red-500">오류가 발생했습니다.</div>;
 
   const testBasicInfo = {

--- a/src/pages/test/TestDetailPage.tsx
+++ b/src/pages/test/TestDetailPage.tsx
@@ -4,19 +4,14 @@ import ProjectInfo from '@/pages/project/_components/projectDetail/ProjectInfo';
 import TestTitle from '@/pages/test/_components/TestTitle';
 import TestRatingBars from '@/pages/test/_components/testDetail/TestRatingBars';
 import PageIssueSection from '@/pages/test/_components/testDetail/page-issue';
-import BeatLoader from 'react-spinners/BeatLoader';
+import PageLoader from '@/components/ui/loader/PageLoader';
 
 export default function TestDetailPage() {
   const params = useParams();
   const projectId = params.projectId;
   const { data: testDetail, isPending, isError } = useGetTestDetail(Number(projectId));
 
-  if (isPending)
-    return (
-      <div className="flex justify-center items-center h-screen">
-        <BeatLoader color="#B3C7AA" />
-      </div>
-    );
+  if (isPending) return <PageLoader />;
   if (isError) return <div className="py-20 text-center text-red-500">오류가 발생했습니다.</div>;
 
   const testBasicInfo = {

--- a/src/pages/test/TestManagePage.tsx
+++ b/src/pages/test/TestManagePage.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
-import { BeatLoader } from 'react-spinners';
 import UseIntersectionObserver from '@/utils/useIntersectionObserver';
 import { useGetTestListInfinite } from '@/store/queries/test/useTestQueries';
 import ScrollToTopButton from '@/components/ui/scrollTopButton/ScrollToTopButton';
 import TestTitle from '@/pages/test/_components/TestTitle';
 import SearchHeader from '@/pages/test/_components/searchHeader/SearchHeader';
 import TestList from '@/pages/test/_components/testList/TestList';
+import PageLoader from '@/components/ui/loader/PageLoader';
 
 export default function TestManagePage() {
   const [searchTerm, setSearchTerm] = useState('');
@@ -41,12 +41,7 @@ export default function TestManagePage() {
     setDateSort('');
   };
 
-  if (isPending)
-    return (
-      <div className="flex justify-center items-center h-screen">
-        <BeatLoader color="#B3C7AA" />
-      </div>
-    );
+  if (isPending) return <PageLoader />;
   if (isError)
     return <div className="col-span-3 text-center text-typography-gray text-16 pt-40">오류가 발생했습니다.</div>;
 

--- a/src/pages/test/_components/testDetail/page-issue/index.tsx
+++ b/src/pages/test/_components/testDetail/page-issue/index.tsx
@@ -8,7 +8,7 @@ import IssueContents from '@/pages/test/_components/testDetail/page-issue/IssueC
 import IssueTabBar, { TabMeta } from '@/pages/test/_components/testDetail/page-issue/IssueTabBar';
 import PageButtons from '@/pages/test/_components/testDetail/page-issue/PageButtons';
 import GoToFigmaButton from '@/pages/test/_components/testDetail/page-issue/GoToFigmaButton';
-import BeatLoader from 'react-spinners/BeatLoader';
+import PageLoader from '@/components/ui/loader/PageLoader';
 
 interface PageIssueSectionProps {
   testDetail: TestDetail;
@@ -31,11 +31,7 @@ export default function PageIssueSection({ testDetail }: PageIssueSectionProps) 
   const { data: issueData, isLoading: isPending, isError } = useGetPageIssue(pageId);
 
   if (isPending) {
-    return (
-      <div className="flex justify-center items-center h-screen">
-        <BeatLoader color="#B3C7AA" />
-      </div>
-    );
+    return <PageLoader />;
   }
   if (isError || !issueData) {
     return <div className="py-20 text-center text-red-500">페이지 이슈 불러오기 실패</div>;

--- a/src/pages/test/_components/testDetail/page-issue/index.tsx
+++ b/src/pages/test/_components/testDetail/page-issue/index.tsx
@@ -8,6 +8,7 @@ import IssueContents from '@/pages/test/_components/testDetail/page-issue/IssueC
 import IssueTabBar, { TabMeta } from '@/pages/test/_components/testDetail/page-issue/IssueTabBar';
 import PageButtons from '@/pages/test/_components/testDetail/page-issue/PageButtons';
 import GoToFigmaButton from '@/pages/test/_components/testDetail/page-issue/GoToFigmaButton';
+import BeatLoader from 'react-spinners/BeatLoader';
 
 interface PageIssueSectionProps {
   testDetail: TestDetail;
@@ -30,7 +31,11 @@ export default function PageIssueSection({ testDetail }: PageIssueSectionProps) 
   const { data: issueData, isLoading: isPending, isError } = useGetPageIssue(pageId);
 
   if (isPending) {
-    return <div className="py-20 text-center">페이지 이슈 로딩 중...</div>;
+    return (
+      <div className="flex justify-center items-center h-screen">
+        <BeatLoader color="#B3C7AA" />
+      </div>
+    );
   }
   if (isError || !issueData) {
     return <div className="py-20 text-center text-red-500">페이지 이슈 불러오기 실패</div>;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,21 +1,24 @@
+import { lazy } from 'react';
 import { Navigate } from 'react-router-dom';
 import { ROUTES } from '@/constants';
 import Layout from '@/components/layout/page-layout/Layout';
-import LandingPage from '@/pages/main/LandingPage';
+// 유저가 바로 보는 or 가벼운 페이지는 즉시 로딩
 import LoginPage from '@/pages/auth/LoginPage';
 import SignupPage from '@/pages/auth/SignupPage';
+import LandingPage from '@/pages/main/LandingPage';
+import DashboardPage from '@/pages/main/DashboardPage';
 import ManualPage from '@/pages/manual/ManualPage';
 import ManualPrivatePage from '@/pages/manual/ManualPrivatePage';
-import DashboardPage from '@/pages/main/DashboardPage';
-import ProjectCreatePage from '@/pages/project/ProjectCreatePage';
-import ProjectDetailPage from '@/pages/project/ProjectDetailPage';
-import ProjectMangePage from '@/pages/project/ProjectMangePage';
-import TestManagePage from '@/pages/test/TestManagePage';
-import TestDetailPage from '@/pages/test/TestDetailPage';
-import SettingPage from '@/pages/setting/SettingPage';
-import ProfileEditPage from '@/pages/setting/ProfileEditPage';
-import PasswordEditPage from '@/pages/setting/PasswordEditPage';
-import ProjectModifyPage from '@/pages/project/ProjectModifyPage';
+// 무거운 페이지, 로딩 잘 걸리는, 중요도 우선순위에서 먼 페이지는 지연 로딩
+const ProjectDetailPage = lazy(() => import('@/pages/project/ProjectDetailPage'));
+const ProjectCreatePage = lazy(() => import('@/pages/project/ProjectCreatePage'));
+const ProjectModifyPage = lazy(() => import('@/pages/project/ProjectModifyPage'));
+const ProjectMangePage = lazy(() => import('@/pages/project/ProjectMangePage'));
+const TestManagePage = lazy(() => import('@/pages/test/TestManagePage'));
+const TestDetailPage = lazy(() => import('@/pages/test/TestDetailPage'));
+const SettingPage = lazy(() => import('@/pages/setting/SettingPage'));
+const ProfileEditPage = lazy(() => import('@/pages/setting/ProfileEditPage'));
+const PasswordEditPage = lazy(() => import('@/pages/setting/PasswordEditPage'));
 
 const routes = [
   { path: ROUTES.LANDING, element: <LandingPage /> },

--- a/src/types/project.type.ts
+++ b/src/types/project.type.ts
@@ -8,13 +8,28 @@ export interface ProjectListData {
   testRate: number;
 }
 
-export interface ProjectResponse {
-  status: string;
-  message: string;
-  data: {
-    ProjectList: ProjectListData[];
-  };
-  code: number;
+export interface ProjectDetailData {
+  projectName: string;
+  projectAdmin: string;
+  projectStatus: string;
+  projectCreatedDate: string;
+  projectEnd: string;
+  testExecutionTime: string | null;
+  rootFigmaPage: string;
+  description: string;
+  fileName: string | null;
+  figmaUrl: string;
+  serviceUrl: string;
+  reportSummary: string | null;
+  testSummary: {
+    totalRoutingTest: number;
+    totalInteractionTest: number;
+    totalMappingTest: number;
+  } | null;
+  pages: Array<{
+    pageName: string;
+    pageBaseUrl: string;
+  }>;
 }
 
 export interface ProjectsParams {


### PR DESCRIPTION
## 🛰️ Issue Number
이슈번호: #81

## 🪐 작업 내용

<작업 사진>
**로딩 중 spinner**
<img width="127" alt="image" src="https://github.com/user-attachments/assets/dd1db75d-76ae-462d-8bd6-cc36b0da0f29" />

**프로젝트 세부 페이지 테이블**
<img width="332" alt="image" src="https://github.com/user-attachments/assets/d34de5d9-bec5-461b-85d1-a051678e2b8d" />

**프로젝트 세부 projectStatus 상태에 따른 UI 컴포넌트**
<img width="991" alt="image" src="https://github.com/user-attachments/assets/7f5d6ed4-1647-4d6f-9fcd-0f4ea1fce551" />
<img width="982" alt="image" src="https://github.com/user-attachments/assets/6f5da8e9-94ce-4edf-9817-96fa6d229884" />

<구현 요약>
- 페이지 로딩 스피너는 전부 저걸로 바꿔줬습니다. 
- 저번 회의 때 준혁이 로컬에서 프로젝트 세부 페이지의 페이지 테이블 정렬이 깨진 걸 발견해서 중앙 정렬로 수정했습니다.
- projectStatus 컴포넌트 만들다가 projectDetailResponse 타입 정의가 필요해 project.type.ts에 정의해주었습니다.
- Button 컴포넌트에서 커스텀 className이 자꾸 BaseClassName에 우선 순위가 밀려 적용이 안되는 것 같아서 조건부처리로 우선순위 높여줬습니다. 
- projectStatus는 'NOT_STARTED', 'IN_PROGRESSED', 'COMPLETED' 이렇게 3개 있어 3개의 상태를 각각 _components에 정리해 분리해주었습니다. 
- 추가적으로 projectStatus가 생김으로써 프로젝트 세부 페이지에 있는 "테스트 재실행" 버튼을 조건부 렌더링을 할 수 있게 돼서 'COMPLETED'일 때만 버튼을 렌더링하여 테스트 실행 전일 때 직관에 맞지 않는 버튼 text, 테스트 실행 중일 때 중복 실행 요청을 방지하려고 했습니다. 
- 그리고 지연로딩에 관해서는 우선 이것저것 하진 않았고 유저가 바로 보는, 중요한 페이지는 즉시 로딩 처리하고 우선 순위에서 조금 먼, 그리고 비교적 무거운 페이지들을 지연 로딩 lazy() 처리한 다음 Suspense로 묶어주어 라우팅 기준으로 속도 개선을 해보았습니다. 
아직 지연 로딩이 적용되지 않은 배포 사이트의 경우 대시보드 페이지에서 로딩 시간이 1.04초, 지연 로딩이 적용된 개발 모드의 대시보드 페이지에선 로딩 시간이 887ms로 약 15% 정도 개선된 것을 확인했고, 그 전에 랜딩 페이지에서도 로딩이 오래 걸렸는데 지연 로딩 적용 후 체감 속도도 감소한 것을 느꼈습니다. (제 로컬에서만 그런 것인지는 확인을 해봐야...) 참고로 개발 모드에서는 파일 압축 전이라 JS만 필터링해서 테스트 해보았습니다. 

## 📚 Reference
하다가 이상하거나 오류 나는 부분, 수정이 필요한 부분이 있으면 언제든지 말씀해주세요.
그리고 storybook이랑 husky에 대해 공부해보고 싶어서 이 프로젝트에 적용해보려고 합니다. 

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] 코드 스타일을 eslint/prettier로 맞췄나요?