### PR TITLE
[ #83 | fix ] 헤더바 라우팅명제거 및 검색 알림 드롭박스 창

### DIFF
--- a/src/components/layout/page-layout/Header.tsx
+++ b/src/components/layout/page-layout/Header.tsx
@@ -1,19 +1,18 @@
-import { useMemo, useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useUserProfile } from '@/store/queries/user/useUserQueries';
 import searchIcon from '@/assets/icons/search.svg';
 import notificationIcon from '@/assets/icons/notification.svg';
 import profileImg from '@/assets/images/짱구.jpg';
-import { menuItems, topMenuItem } from '@/components/layout/sidebar/_components/SidebarData';
 import { setProjectName } from '@/store/redux/reducers/project';
 import { saveRecentSearch, getRecentSearches, clearRecentSearches } from '@/utils/recentSearch';
 import { useGetProjectList } from '@/store/queries/project/useProjectQueries';
 import { useDebounce } from '@/hooks/useDebounce';
 import BellBadge from '@/components/ui/BellBadge';
+import { ProjectListData } from '@/types/project.type';
 
 export default function Header({ onMenuClick }: { onMenuClick?: () => void }) {
-  const location = useLocation();
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const [inputValue, setInputValue] = useState('');
@@ -24,7 +23,7 @@ export default function Header({ onMenuClick }: { onMenuClick?: () => void }) {
   const debouncedInputValue = useDebounce(inputValue, 300);
   const { data: suggestedProjects = [] } = useGetProjectList({ projectName: debouncedInputValue });
   // 전체 프로젝트 리스트 불러오기 (진행상태 태그용)
-  const { data: allProjects = [] } = useGetProjectList();
+  const { data: allProjects = [] }: { data?: ProjectListData[] } = useGetProjectList();
 
   useEffect(() => {
     if (!showNotification) return;
@@ -60,15 +59,6 @@ export default function Header({ onMenuClick }: { onMenuClick?: () => void }) {
   }
 
   const { data: profile } = useUserProfile();
-
-  // 현재 경로에 있는 사이드 바의 메뉴 아이템 찾기
-  const currentPage = useMemo(() => {
-    const allMenuItems = [...menuItems, topMenuItem];
-    const matchedItem = allMenuItems.find(
-      (item) => item.path === location.pathname || (location.pathname.startsWith(item.path) && item.path !== '/')
-    );
-    return matchedItem ? matchedItem.title : '';
-  }, [location.pathname]);
 
   // 알림 여부 예시 (실제 알림 데이터 연동 시 수정)
   const hasNotification = false; // 알림이 있을 때 true로 변경
@@ -118,7 +108,7 @@ export default function Header({ onMenuClick }: { onMenuClick?: () => void }) {
                 <>
                   <div className="text-xs text-blue-400 mb-1 mt-2">추천 프로젝트</div>
                   <ul>
-                    {suggestedProjects.map((proj: any) => (
+                    {suggestedProjects.map((proj: ProjectListData) => (
                       <li
                         key={proj.projectName}
                         className="flex items-center justify-between text-blue-700 text-sm py-1 px-2 hover:bg-blue-50 rounded cursor-pointer"
@@ -159,7 +149,9 @@ export default function Header({ onMenuClick }: { onMenuClick?: () => void }) {
                 <ul className="mb-2">
                   {recentSearches.map((item) => {
                     // 프로젝트명과 완전 일치하는 프로젝트 찾기
-                    const matched = allProjects.find((p: any) => p.projectName.toLowerCase() === item.toLowerCase());
+                    const matched = allProjects.find(
+                      (p: ProjectListData) => p.projectName.toLowerCase() === item.toLowerCase()
+                    );
                     return (
                       <li
                         key={item}

--- a/src/components/layout/page-layout/Header.tsx
+++ b/src/components/layout/page-layout/Header.tsx
@@ -42,9 +42,9 @@ export default function Header({ onMenuClick }: { onMenuClick?: () => void }) {
         </button>
       )}
       {/* 현재 페이지 이름 */}
-      <h1 className="font-bm font-medium text-lg md:text-2xl cursor-default flex-shrink-0 truncate max-w-[120px] md:max-w-[200px]">
+      {/* <h1 className="font-bm font-medium text-lg md:text-2xl cursor-default flex-shrink-0 truncate max-w-[120px] md:max-w-[200px]">
         {currentPage}
-      </h1>
+      </h1> */}
       {/* 검색창 (모바일에서는 숨김) */}
       <div className="relative flex-1 max-w-[320px] w-full bg-white py-2 px-4 mx-2 rounded-full hidden md:flex">
         <button type="button" onClick={handleSearch}>

--- a/src/components/layout/page-layout/Header.tsx
+++ b/src/components/layout/page-layout/Header.tsx
@@ -18,6 +18,7 @@ export default function Header({ onMenuClick }: { onMenuClick?: () => void }) {
   const [inputValue, setInputValue] = useState('');
   const [showRecent, setShowRecent] = useState(false);
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
+  const [showNotification, setShowNotification] = useState(false);
   const debouncedInputValue = useDebounce(inputValue, 300);
   const { data: suggestedProjects = [] } = useGetProjectList({ projectName: debouncedInputValue });
   // 전체 프로젝트 리스트 불러오기 (진행상태 태그용)
@@ -186,9 +187,16 @@ export default function Header({ onMenuClick }: { onMenuClick?: () => void }) {
       </div>
       <div className="flex items-center gap-2 mr-8 lg:gap-4 min-w-0">
         {/* 알림 버튼 (모바일에서는 숨김) */}
-        <div className="hidden lg:flex mr-0 items-center">
-          <button>
+        <div className="hidden lg:flex mr-0 items-center relative">
+          <button className="relative" onClick={() => setShowNotification((prev) => !prev)} tabIndex={0}>
             <img src={notificationIcon} alt="notification button" />
+            {showNotification && (
+              <div
+                className="absolute right-0 mt-2 w-64 bg-white border border-gray-200 rounded-lg shadow-lg p-4 z-50"
+                style={{ minHeight: 48 }}>
+                <p className="text-gray-400 text-sm text-center">최근 알림이 없습니다</p>
+              </div>
+            )}
           </button>
         </div>
         {/* 프로필 버튼 */}

--- a/src/components/layout/page-layout/Header.tsx
+++ b/src/components/layout/page-layout/Header.tsx
@@ -46,9 +46,9 @@ export default function Header({ onMenuClick }: { onMenuClick?: () => void }) {
         {currentPage}
       </h1> */}
       {/* 검색창 (모바일에서는 숨김) */}
-      <div className="relative flex-1 max-w-[320px] w-full bg-white py-2 px-4 mx-2 rounded-full hidden md:flex">
+      <div className="relative flex-1 max-w-[760px] w-full bg-white ml-8 py-2 px-8 mx-2 rounded-full hidden md:flex">
         <button type="button" onClick={handleSearch}>
-          <img src={searchIcon} alt="search button" className="absolute left-4 top-2" />
+          <img src={searchIcon} alt="search button" className="absolute left-4 top-2 w-6 h-6" />
         </button>
         <input
           type="text"
@@ -63,9 +63,9 @@ export default function Header({ onMenuClick }: { onMenuClick?: () => void }) {
           }}
         />
       </div>
-      <div className="flex items-center gap-2 lg:gap-4 min-w-0">
+      <div className="flex items-center gap-2 mr-8 lg:gap-4 min-w-0">
         {/* 알림 버튼 (모바일에서는 숨김) */}
-        <div className="hidden lg:flex items-center">
+        <div className="hidden lg:flex mr-0 items-center">
           <button>
             <img src={notificationIcon} alt="notification button" />
           </button>

--- a/src/components/ui/BellBadge.tsx
+++ b/src/components/ui/BellBadge.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface BellBadgeProps {
+  show?: boolean;
+  badgeContent?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function BellBadge({ show, badgeContent, children, className }: BellBadgeProps) {
+  return (
+    <span className="relative inline-block">
+      {children}
+      {show && (
+        <span
+          className={`absolute -top-1 -right-1 flex items-center justify-center w-3 h-3 rounded-full bg-red-500 text-white text-[10px] font-bold shadow ${className || ''}`}>
+          {badgeContent || ''}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react';
+
+export function useDebounce<T>(value: T, delay: number = 300): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/src/utils/recentSearch.ts
+++ b/src/utils/recentSearch.ts
@@ -1,0 +1,17 @@
+const RECENT_KEY = 'recent_searches';
+
+export function saveRecentSearch(keyword: string) {
+  if (!keyword.trim()) return;
+  const prev = JSON.parse(localStorage.getItem(RECENT_KEY) || '[]');
+  const filtered = prev.filter((item: string) => item !== keyword);
+  const updated = [keyword, ...filtered].slice(0, 5);
+  localStorage.setItem(RECENT_KEY, JSON.stringify(updated));
+}
+
+export function getRecentSearches(): string[] {
+  return JSON.parse(localStorage.getItem(RECENT_KEY) || '[]');
+}
+
+export function clearRecentSearches() {
+  localStorage.removeItem(RECENT_KEY);
+}


### PR DESCRIPTION
## 🛰️ Issue Number
이슈번호: #83

## 🪐 작업 내용

<작업 사진>
<img width="820" alt="image" src="https://github.com/user-attachments/assets/8e292690-c1e8-4443-b9f9-5f89e6f58588" />
<img width="284" alt="image" src="https://github.com/user-attachments/assets/06751143-8fc8-4eb6-9d03-23349d294869" />


<구현 요약>
- 기존에 있던 라우팅명을 제거했습니다.
- 그리고 검색창을 누르면 하단에 검색목록이 뜨는데 이 떄 최근 검색어가 로딩이 지연됨을 debounce로 잡았습니다.
- 이 저장은 localstorage로 저장하여 개인 계정 및 local에서만 적용됩니다.
- 알림 아이콘도 클릭 시 하단에 "최근 알림이 없습니다."정도로 띄우고 알림 갯수에 따라서 뱃지도 만들었으나 테스트 하지 않았습니다.
- 추후에 ai연결되면서 같이 수정 보겠습니다.
- 그리고 프로젝트 검색에 따라 프로젝트명 자체 저장도 하고싶었으나 api 를 contain에 따라 받아야해서 보류한 상태입니다.

<커밋 설명>
[ [#83](https://github.com/KW-AUTA/client/issues/83) | fix ] 현재페이지명 삭제

[ [#83](https://github.com/KW-AUTA/client/issues/83) | fix ] 데스크탑뷰 헤더바 조정 : 서치바를 데스크탑 뷰에서 최대 760px로 늘렸습니다 그리고 전체적인 마진이나 패딩값을 손봤습니다.

[ [#83](https://github.com/KW-AUTA/client/issues/83) | feat ] 검색 localstorage 저장 기능 : recentSearch.tsx 파일에 상수값으로 기능을 재사용성이 좋게 만들었으며 파싱해서 로컬스토리지에 저장하는 방식입니다.

[ [#83](https://github.com/KW-AUTA/client/issues/83) | feat ] debounce 훅 추가 : 살짝 딜레이 타임을 줘서 검색을 할 때 무한루프에 빠지지 않도록 했습니다. 이 부분이 조금 중요한듯합니다 지연시간은 300ms 입니다.

[ [#83](https://github.com/KW-AUTA/client/issues/83) | fix ] 최근 검색어 로딩 빠르게 : 여기에서는 debounce 훅을 추가해놓고 안불러와서 그 부분이랑 검색어 우측에 진행상태 뱃지를 달아놓고 싶었으나 이 부분이 api가 필요한 것 같아보입니다.

[ [#83](https://github.com/KW-AUTA/client/issues/83) | feat ] 헤더바 알림내역 창 추가 : 같은 방식으로 모달창 추가하고 서로 클릭이벤트로 연결해서 하나만 보이게끔 했습니다. 데스크탑뷰여도 겹치게 보이기 때문입니다

[ [#83](https://github.com/KW-AUTA/client/issues/83) | feat ] 헤더바 알림 뱃지 기능 : 알림이 1개 이상 있다면 종 모양 우측상단에 뱃지모양이 뜨는데 추후에 테스트해서 보여드리겠습니다.




## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] 코드 스타일을 eslint/prettier로 맞췄나요?