### PR TITLE
[ #84 | feat ] 에러 모달 세팅

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,7 +57,7 @@ function AppWithErrorModal({ children }: { children: React.ReactNode }) {
   return (
     <>
       {children}
-      <ErrorModal open={showErrorModal} message={errorMessage} onClose={() => setShowErrorModal(false)} />
+      <ErrorModal open={showErrorModal} message={errorMessage} />
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,9 +6,61 @@ import { store } from './store/redux/store';
 import './styles/index.css';
 import routes from '@/routes';
 import { ToastContainer } from 'react-toastify';
+import { useEffect, useState } from 'react';
+import ErrorModal from '@/components/modal/ErrorModal';
+import axios from 'axios';
 
 const queryClient = new QueryClient();
 const router = createBrowserRouter(routes);
+
+function AppWithErrorModal({ children }: { children: React.ReactNode }) {
+  const [showErrorModal, setShowErrorModal] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  // 네트워크 연결 끊김 감지
+  useEffect(() => {
+    const handleOffline = () => {
+      setErrorMessage('인터넷 연결이 끊어졌습니다.');
+      setShowErrorModal(true);
+    };
+    window.addEventListener('offline', handleOffline);
+    return () => window.removeEventListener('offline', handleOffline);
+  }, []);
+
+  // axios 요청 시간 초과 감지 (전역 인터셉터)
+  useEffect(() => {
+    const interceptor = axios.interceptors.response.use(
+      (response) => response,
+      (error) => {
+        if (error.code === 'ECONNABORTED') {
+          setErrorMessage('요청이 너무 오래 걸립니다. 잠시 후 다시 시도해 주세요.');
+          setShowErrorModal(true);
+        } else if (error.response) {
+          // 서버에서 에러 응답이 온 경우
+          if (error.response.status >= 500) {
+            setErrorMessage('서버에 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.');
+            setShowErrorModal(true);
+          } else if (error.response.status === 404) {
+            setErrorMessage('요청하신 리소스를 찾을 수 없습니다.');
+            setShowErrorModal(true);
+          }
+        } else if (error.message === 'Network Error') {
+          setErrorMessage('네트워크 연결에 문제가 있습니다.');
+          setShowErrorModal(true);
+        }
+        return Promise.reject(error);
+      }
+    );
+    return () => axios.interceptors.response.eject(interceptor);
+  }, []);
+
+  return (
+    <>
+      {children}
+      <ErrorModal open={showErrorModal} message={errorMessage} onClose={() => setShowErrorModal(false)} />
+    </>
+  );
+}
 
 function App() {
   return (
@@ -22,4 +74,10 @@ function App() {
   );
 }
 
-export default App;
+export default function WrappedApp() {
+  return (
+    <AppWithErrorModal>
+      <App />
+    </AppWithErrorModal>
+  );
+}

--- a/src/components/modal/CommonModal.tsx
+++ b/src/components/modal/CommonModal.tsx
@@ -10,6 +10,7 @@ interface CommonModalProps {
   confirmText?: string;
   cancelText?: string;
   showCancel?: boolean;
+  hideCancel?: boolean; // 추가
   confirmButtonClassName?: string;
   cancelButtonClassName?: string;
 }
@@ -23,6 +24,7 @@ export default function CommonModal({
   confirmText = '확인',
   cancelText = '취소',
   showCancel = true,
+  hideCancel = false,
   confirmButtonClassName = '',
   cancelButtonClassName = ''
 }: CommonModalProps) {
@@ -42,7 +44,7 @@ export default function CommonModal({
               className={`w-[120px] h-[44px] text-[18px] font-medium bg-white border border-gray-300 hover:bg-gray-100 ${confirmButtonClassName}`}
             />
           )}
-          {showCancel && (
+          {showCancel && !hideCancel && (
             <Button
               text={cancelText}
               onClick={onClose}

--- a/src/components/modal/ErrorModal.tsx
+++ b/src/components/modal/ErrorModal.tsx
@@ -1,0 +1,26 @@
+import CommonModal from './CommonModal';
+
+interface ErrorModalProps {
+  open: boolean;
+  message: string;
+}
+
+export default function ErrorModal({ open, message }: ErrorModalProps) {
+  const handleRetry = () => {
+    window.location.reload();
+  };
+  return (
+    <CommonModal
+      isOpen={open}
+      onClose={handleRetry}
+      onConfirm={handleRetry}
+      title="에러발생"
+      confirmText="재시도"
+      hideCancel={true}>
+      <div className="flex flex-col items-center">
+        <p className="text-center text-lg text-gray-700 mb-6">{message}</p>
+        {/* 버튼 스타일은 CommonModal에서 조정 */}
+      </div>
+    </CommonModal>
+  );
+}


### PR DESCRIPTION
## 🛰️ Issue Number
이슈번호: #84

## 🪐 작업 내용
일단 새벽에 PR올리자마자 main으로 푸시되기전에 여기서 작업하던게 있어서
83번 브랜치를 통해 84번 이슈를 PR하게 된 점 죄송합니다 .!
<작업 사진>
<img width="1465" alt="image" src="https://github.com/user-attachments/assets/2ce4dd96-c15b-4dc3-8692-a146ee403d8b" />

일단 이 한 장으로 요약 되는 이슈입니다.

<구현 요약>
- 연결이 끊어지거나 10000ms 이상 로딩이 지연될 때 생기는 에러 모달 창입니다.

<커밋 설명>
- [ [#84](https://github.com/KW-AUTA/client/issues/84) | feat ] 에러모달을 위한 에러환경 설정 : 에러 모달을 위해 지연로딩 및 인터넷 끊김 에러 설정을 했습니다.
- [ [#84](https://github.com/KW-AUTA/client/issues/84) | fix ] 에러모달 close 옵션 재설정 : 사전에 close 옵션을 에러모달에서는 제거하고자 했으나 공용 컴포넌트인 CommonModal에 있는 기존 세팅을 강제로 해치려하니 오류가 떠서 그냥 false로 하고 되돌려놨습니다.
- [ [#84](https://github.com/KW-AUTA/client/issues/84) | feat ] 에러모달 세팅 : 에러모달을 위한 기본 디자인 세팅과 불러오는 과정을 설정했습니다.

에러 모달을 테스트로 보고싶다면 개발자모드-네트워크에서 오프라인으로 설정하시면 볼 수 있습니다.

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] 코드 스타일을 eslint/prettier로 맞췄나요?