### PR TITLE
[ #94 | Fix ] SearchBar에 StatusBadge 적용

### DIFF
--- a/src/components/layout/page-layout/Header.tsx
+++ b/src/components/layout/page-layout/Header.tsx
@@ -12,6 +12,7 @@ import { useDebounce } from '@/hooks/useDebounce';
 import BellBadge from '@/components/ui/BellBadge';
 import { ProjectListData } from '@/types/project.type';
 import Portal from './Portal';
+import StatusBadge, { StatusType } from '@/pages/project/_components/StatusBadge';
 // import { RootState } from '@/store/redux/store';
 
 export default function Header({ onMenuClick }: { onMenuClick?: () => void }) {
@@ -148,14 +149,7 @@ export default function Header({ onMenuClick }: { onMenuClick?: () => void }) {
                             setTimeout(() => handleSearch(proj.projectName), 0);
                           }}>
                           <span>{proj.projectName}</span>
-                          <span
-                            className={
-                              proj.projectStatus === 'COMPLETED'
-                                ? 'ml-2 px-2 py-0.5 rounded-full text-xs font-semibold bg-green-100 text-green-700'
-                                : 'ml-2 px-2 py-0.5 rounded-full text-xs font-semibold bg-yellow-100 text-yellow-700'
-                            }>
-                            {proj.projectStatus === 'COMPLETED' ? '완료' : '진행중'}
-                          </span>
+                          <StatusBadge status={proj.projectStatus as StatusType} className="ml-2" />
                         </li>
                       ))}
                     </ul>
@@ -194,16 +188,7 @@ export default function Header({ onMenuClick }: { onMenuClick?: () => void }) {
                             }}>
                             {item}
                           </span>
-                          {matched && (
-                            <span
-                              className={
-                                matched.projectStatus === 'COMPLETED'
-                                  ? 'ml-2 px-2 py-0.5 rounded-full text-xs font-semibold bg-green-100 text-green-700'
-                                  : 'ml-2 px-2 py-0.5 rounded-full text-xs font-semibold bg-yellow-100 text-yellow-700'
-                              }>
-                              {matched.projectStatus === 'COMPLETED' ? '완료' : '진행중'}
-                            </span>
-                          )}
+                          {matched && <StatusBadge status={matched.projectStatus as StatusType} className="ml-2" />}
                           <button
                             className="ml-2 text-gray-400 hover:text-red-400 opacity-70 group-hover:opacity-100 transition"
                             onMouseDown={(e) => {

--- a/src/components/layout/page-layout/Header.tsx
+++ b/src/components/layout/page-layout/Header.tsx
@@ -11,7 +11,6 @@ import { useGetProjectList } from '@/store/queries/project/useProjectQueries';
 import { useDebounce } from '@/hooks/useDebounce';
 import BellBadge from '@/components/ui/BellBadge';
 import { ProjectListData } from '@/types/project.type';
-import Portal from './Portal';
 import StatusBadge, { StatusType } from '@/pages/project/_components/StatusBadge';
 // import { RootState } from '@/store/redux/store';
 
@@ -25,7 +24,7 @@ export default function Header({ onMenuClick }: { onMenuClick?: () => void }) {
   const notificationRef = useRef<HTMLDivElement>(null);
   const debouncedInputValue = useDebounce(inputValue, 300);
   const inputRef = useRef<HTMLInputElement>(null);
-  const [dropdownPos, setDropdownPos] = useState({ left: 0, top: 0, width: 0 });
+  // const [dropdownPos, setDropdownPos] = useState({ left: 0, top: 0, width: 0 });
   // const projectName = useSelector((state: RootState) => state.searchReducer.projectName);
   const { data: suggestedProjects = [] } = useGetProjectList({
     projectName: debouncedInputValue,
@@ -42,21 +41,21 @@ export default function Header({ onMenuClick }: { onMenuClick?: () => void }) {
   //   { enabled: !!debouncedInputValue }
   // );
 
-  function updateDropdownPos() {
-    if (inputRef.current) {
-      const rect = inputRef.current.getBoundingClientRect();
-      setDropdownPos({ left: rect.left, top: rect.bottom, width: rect.width });
-    }
-  }
+  // function updateDropdownPos() {
+  //   if (inputRef.current) {
+  //     const rect = inputRef.current.getBoundingClientRect();
+  //     setDropdownPos({ left: rect.left, top: rect.bottom, width: rect.width });
+  //   }
+  // }
 
-  useEffect(() => {
-    if (!showRecent) return;
-    updateDropdownPos();
-    window.addEventListener('resize', updateDropdownPos);
-    return () => {
-      window.removeEventListener('resize', updateDropdownPos);
-    };
-  }, [showRecent]);
+  // useEffect(() => {
+  //   if (!showRecent) return;
+  //   updateDropdownPos();
+  //   window.addEventListener('resize', updateDropdownPos);
+  //   return () => {
+  //     window.removeEventListener('resize', updateDropdownPos);
+  //   };
+  // }, [showRecent]);
 
   const handleSearch = (keyword?: string) => {
     const searchWord = keyword ?? inputValue;
@@ -70,7 +69,6 @@ export default function Header({ onMenuClick }: { onMenuClick?: () => void }) {
   };
 
   const handleInputFocus = () => {
-    updateDropdownPos();
     setShowRecent(true);
     setRecentSearches(getRecentSearches());
   };
@@ -124,89 +122,80 @@ export default function Header({ onMenuClick }: { onMenuClick?: () => void }) {
           onFocus={handleInputFocus}
         />
         {showRecent && (
-          <Portal>
-            <div
-              className="fixed z-[9999] bg-white border border-gray-200 rounded-lg shadow-lg p-4 max-h-60 overflow-auto"
-              style={{
-                left: dropdownPos.left,
-                top: dropdownPos.top + 12,
-                width: dropdownPos.width,
-                minHeight: 48,
-                minWidth: dropdownPos.width,
-                maxWidth: 360
-              }}>
-              {inputValue.trim() ? (
-                suggestedProjects.length > 0 ? (
-                  <>
-                    <div className="text-xs text-blue-400 mb-1 mt-2">추천 프로젝트</div>
-                    <ul>
-                      {suggestedProjects.map((proj: ProjectListData) => (
-                        <li
-                          key={proj.projectName}
-                          className="flex items-center justify-between text-blue-700 text-sm py-1 px-2 hover:bg-blue-50 rounded cursor-pointer"
-                          onMouseDown={() => {
-                            setInputValue(proj.projectName);
-                            setTimeout(() => handleSearch(proj.projectName), 0);
-                          }}>
-                          <span>{proj.projectName}</span>
-                          <StatusBadge status={proj.projectStatus as StatusType} className="ml-2" />
-                        </li>
-                      ))}
-                    </ul>
-                  </>
-                ) : (
-                  <p className="text-gray-400 text-sm text-center py-4">일치하는 프로젝트가 없습니다</p>
-                )
-              ) : recentSearches.length === 0 ? (
-                <p className="text-gray-400 text-sm text-center py-4">최근 검색어가 없습니다</p>
-              ) : (
+          <div
+            className="absolute left-0 top-full mt-2 w-full min-w-[180px] max-w-[360px] md:max-w-none bg-white border border-gray-200 rounded-lg shadow-lg p-4 max-h-60 overflow-auto sm:w-full sm:left-0 sm:right-0 sm:mx-auto z-[9999]"
+            style={{ minHeight: 48 }}>
+            {inputValue.trim() ? (
+              suggestedProjects.length > 0 ? (
                 <>
-                  <button
-                    className="block w-full text-right text-xs text-gray-400 hover:text-red-400 mb-2"
-                    onMouseDown={(e) => {
-                      e.preventDefault();
-                      clearRecentSearches();
-                      setRecentSearches([]);
-                    }}>
-                    전체 삭제
-                  </button>
-                  <div className="text-xs text-gray-400 mb-1">최근 검색어</div>
-                  <ul className="mb-2">
-                    {recentSearches.map((item) => {
-                      const matched = suggestedProjects.find(
-                        (p: ProjectListData) => p.projectName.toLowerCase() === item.toLowerCase()
-                      );
-                      return (
-                        <li
-                          key={item}
-                          className="flex items-center text-gray-700 text-sm py-1 px-2 hover:bg-gray-100 rounded cursor-pointer group">
-                          <span
-                            className="flex-1"
-                            onMouseDown={() => {
-                              setInputValue(item);
-                              setTimeout(() => handleSearch(item), 0);
-                            }}>
-                            {item}
-                          </span>
-                          {matched && <StatusBadge status={matched.projectStatus as StatusType} className="ml-2" />}
-                          <button
-                            className="ml-2 text-gray-400 hover:text-red-400 opacity-70 group-hover:opacity-100 transition"
-                            onMouseDown={(e) => {
-                              e.stopPropagation();
-                              removeRecentSearch(item);
-                            }}
-                            tabIndex={-1}
-                            aria-label="검색어 삭제">
-                            ×
-                          </button>
-                        </li>
-                      );
-                    })}
+                  <div className="text-xs text-blue-400 mb-1 mt-2">추천 프로젝트</div>
+                  <ul>
+                    {suggestedProjects.map((proj: ProjectListData) => (
+                      <li
+                        key={proj.projectName}
+                        className="flex items-center justify-between text-blue-700 text-sm py-1 px-2 hover:bg-blue-50 rounded cursor-pointer"
+                        onMouseDown={() => {
+                          setInputValue(proj.projectName);
+                          setTimeout(() => handleSearch(proj.projectName), 0);
+                        }}>
+                        <span>{proj.projectName}</span>
+                        <StatusBadge status={proj.projectStatus as StatusType} className="ml-2" />
+                      </li>
+                    ))}
                   </ul>
                 </>
-              )}
-            </div>
-          </Portal>
+              ) : (
+                <p className="text-gray-400 text-sm text-center py-4">일치하는 프로젝트가 없습니다</p>
+              )
+            ) : recentSearches.length === 0 ? (
+              <p className="text-gray-400 text-sm text-center py-4">최근 검색어가 없습니다</p>
+            ) : (
+              <>
+                <button
+                  className="block w-full text-right text-xs text-gray-400 hover:text-red-400 mb-2"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    clearRecentSearches();
+                    setRecentSearches([]);
+                  }}>
+                  전체 삭제
+                </button>
+                <div className="text-xs text-gray-400 mb-1">최근 검색어</div>
+                <ul className="mb-2">
+                  {recentSearches.map((item) => {
+                    const matched = suggestedProjects.find(
+                      (p: ProjectListData) => p.projectName.toLowerCase() === item.toLowerCase()
+                    );
+                    return (
+                      <li
+                        key={item}
+                        className="flex items-center text-gray-700 text-sm py-1 px-2 hover:bg-gray-100 rounded cursor-pointer group">
+                        <span
+                          className="flex-1"
+                          onMouseDown={() => {
+                            setInputValue(item);
+                            setTimeout(() => handleSearch(item), 0);
+                          }}>
+                          {item}
+                        </span>
+                        {matched && <StatusBadge status={matched.projectStatus as StatusType} className="ml-2" />}
+                        <button
+                          className="ml-2 text-gray-400 hover:text-red-400 opacity-70 group-hover:opacity-100 transition"
+                          onMouseDown={(e) => {
+                            e.stopPropagation();
+                            removeRecentSearch(item);
+                          }}
+                          tabIndex={-1}
+                          aria-label="검색어 삭제">
+                          ×
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </>
+            )}
+          </div>
         )}
       </div>
       <div className="flex items-center gap-2 mr-8 lg:gap-4 min-w-0">

--- a/src/components/layout/page-layout/Header.tsx
+++ b/src/components/layout/page-layout/Header.tsx
@@ -123,7 +123,7 @@ export default function Header({ onMenuClick }: { onMenuClick?: () => void }) {
         />
         {showRecent && (
           <div
-            className="absolute left-0 top-full mt-2 w-full min-w-[180px] max-w-[360px] md:max-w-none bg-white border border-gray-200 rounded-lg shadow-lg p-4 max-h-60 overflow-auto sm:w-full sm:left-0 sm:right-0 sm:mx-auto z-[9999]"
+            className="absolute left-0 top-full mt-2 w-full min-w-[180px] max-w-[360px] md:max-w-none bg-white border border-gray-200 rounded-lg shadow-lg p-4 max-h-60 overflow-auto sm:w-full sm:left-0 sm:right-0 sm:mx-auto z-[99999]"
             style={{ minHeight: 48 }}>
             {inputValue.trim() ? (
               suggestedProjects.length > 0 ? (

--- a/src/components/layout/page-layout/Header.tsx
+++ b/src/components/layout/page-layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { useUserProfile } from '@/store/queries/user/useUserQueries';

--- a/src/components/layout/page-layout/Portal.tsx
+++ b/src/components/layout/page-layout/Portal.tsx
@@ -1,0 +1,8 @@
+import { createPortal } from 'react-dom';
+import { ReactNode } from 'react';
+
+export default function Portal({ children }: { children: ReactNode }) {
+  if (typeof window === 'undefined') return null;
+  const el = document.getElementById('portal-root') || document.body;
+  return createPortal(children, el);
+}

--- a/src/components/ui/input/Input.tsx
+++ b/src/components/ui/input/Input.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, InputHTMLAttributes, useId } from 'react';
+import { forwardRef, ChangeEvent, InputHTMLAttributes, useId } from 'react';
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
@@ -10,17 +10,10 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   onEnterPress?: () => void;
 }
 
-export default function Input({
-  label,
-  name,
-  value,
-  className = '',
-  labelClassName = '',
-  required = false,
-  onChange,
-  onEnterPress,
-  ...props
-}: InputProps) {
+const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  { label, name, value, className = '', labelClassName = '', required = false, onChange, onEnterPress, ...props },
+  ref
+) {
   const inputId = useId();
 
   const handleKeyUp = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -38,6 +31,7 @@ export default function Input({
         </label>
       )}
       <input
+        ref={ref}
         id={inputId}
         type="text"
         className={`w-full bg-background border-[0.5px] border-typography-gray rounded-15 px-4 py-3 placeholder:text-typography-gray focus:border-none focus:shadow-custom focus:outline-none ${className}`}
@@ -50,4 +44,6 @@ export default function Input({
       />
     </div>
   );
-}
+});
+
+export default Input;

--- a/src/pages/test/_components/searchHeader/SearchHeader.tsx
+++ b/src/pages/test/_components/searchHeader/SearchHeader.tsx
@@ -4,7 +4,6 @@ import Select from '@/components/ui/select/Select';
 import Button from '@/components/ui/button/Button';
 import searchIcon from '@/assets/icons/search.svg';
 import ResetIcon from '@/assets/icons/refresh.svg?react';
-import Portal from '@/components/layout/page-layout/Portal'; // Portal 경로에 맞게 import
 
 interface SearchHeaderProps {
   inputValue: string;
@@ -31,28 +30,23 @@ export default function SearchHeader({
   onDateSortChange
 }: SearchHeaderProps) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const [dropdownPos, setDropdownPos] = useState({ left: 0, top: 0, width: 0 });
   const [showRecent, setShowRecent] = useState(false);
 
-  function updateDropdownPos() {
-    if (inputRef.current) {
-      const rect = inputRef.current.getBoundingClientRect();
-      setDropdownPos({ left: rect.left, top: rect.bottom, width: rect.width });
-    }
-  }
-
   const handleInputFocus = () => {
-    updateDropdownPos();
     setShowRecent(true);
     // 최근 검색어 불러오기 등 추가 로직
   };
 
   useEffect(() => {
     if (!showRecent) return;
-    updateDropdownPos();
-    window.addEventListener('resize', updateDropdownPos);
+    // updateDropdownPos(); // 제거됨
+    window.addEventListener('resize', () => {
+      // updateDropdownPos(); // 제거됨
+    });
     return () => {
-      window.removeEventListener('resize', updateDropdownPos);
+      window.removeEventListener('resize', () => {
+        // updateDropdownPos(); // 제거됨
+      });
     };
   }, [showRecent]);
 
@@ -62,7 +56,7 @@ export default function SearchHeader({
     function handleClickOutside(e: MouseEvent | TouchEvent) {
       // inputRef와 드롭다운 영역을 모두 포함해서 체크
       const input = inputRef.current;
-      const dropdown = document.getElementById('search-dropdown-portal');
+      const dropdown = document.getElementById('search-dropdown-portal'); // 제거됨
       if (input && !input.contains(e.target as Node) && dropdown && !dropdown.contains(e.target as Node)) {
         setShowRecent(false);
       }
@@ -101,20 +95,11 @@ export default function SearchHeader({
           onFocus={handleInputFocus}
         />
         {showRecent && (
-          <Portal>
-            <div
-              id="search-dropdown-portal"
-              className="fixed z-[9999] bg-white border border-gray-200 rounded-lg shadow-lg p-4 max-h-60 overflow-auto"
-              style={{
-                left: dropdownPos.left,
-                top: dropdownPos.top + 8,
-                width: dropdownPos.width,
-                minWidth: 180,
-                maxWidth: 510 // 필요시 input의 max-width와 맞춤
-              }}>
-              {/* 드롭다운 내용 */}
-            </div>
-          </Portal>
+          <div
+            className="absolute left-0 top-full mt-2 w-full min-w-[180px] max-w-[510px] md:max-w-none bg-white border border-gray-200 rounded-lg shadow-lg p-4 max-h-60 overflow-auto z-[9999]"
+            style={{ minHeight: 48 }}>
+            {/* 드롭다운 내용 */}
+          </div>
         )}
       </div>
 

--- a/src/pages/test/_components/searchHeader/SearchHeader.tsx
+++ b/src/pages/test/_components/searchHeader/SearchHeader.tsx
@@ -56,6 +56,27 @@ export default function SearchHeader({
     };
   }, [showRecent]);
 
+  useEffect(() => {
+    if (!showRecent) return;
+
+    function handleClickOutside(e: MouseEvent | TouchEvent) {
+      // inputRef와 드롭다운 영역을 모두 포함해서 체크
+      const input = inputRef.current;
+      const dropdown = document.getElementById('search-dropdown-portal');
+      if (input && !input.contains(e.target as Node) && dropdown && !dropdown.contains(e.target as Node)) {
+        setShowRecent(false);
+      }
+    }
+
+    window.addEventListener('mousedown', handleClickOutside);
+    window.addEventListener('touchstart', handleClickOutside);
+
+    return () => {
+      window.removeEventListener('mousedown', handleClickOutside);
+      window.removeEventListener('touchstart', handleClickOutside);
+    };
+  }, [showRecent]);
+
   return (
     <section className="flex items-center justify-between w-full gap-4 pt-5 pb-9">
       <div className="relative flex-1 max-w-[510px] min-w-0">
@@ -82,6 +103,7 @@ export default function SearchHeader({
         {showRecent && (
           <Portal>
             <div
+              id="search-dropdown-portal"
               className="fixed z-[9999] bg-white border border-gray-200 rounded-lg shadow-lg p-4 max-h-60 overflow-auto"
               style={{
                 left: dropdownPos.left,

--- a/src/pages/test/_components/searchHeader/SearchHeader.tsx
+++ b/src/pages/test/_components/searchHeader/SearchHeader.tsx
@@ -39,32 +39,15 @@ export default function SearchHeader({
 
   useEffect(() => {
     if (!showRecent) return;
-    // updateDropdownPos(); // 제거됨
-    window.addEventListener('resize', () => {
-      // updateDropdownPos(); // 제거됨
-    });
-    return () => {
-      window.removeEventListener('resize', () => {
-        // updateDropdownPos(); // 제거됨
-      });
-    };
-  }, [showRecent]);
-
-  useEffect(() => {
-    if (!showRecent) return;
-
     function handleClickOutside(e: MouseEvent | TouchEvent) {
-      // inputRef와 드롭다운 영역을 모두 포함해서 체크
       const input = inputRef.current;
-      const dropdown = document.getElementById('search-dropdown-portal'); // 제거됨
+      const dropdown = document.getElementById('search-dropdown');
       if (input && !input.contains(e.target as Node) && dropdown && !dropdown.contains(e.target as Node)) {
         setShowRecent(false);
       }
     }
-
     window.addEventListener('mousedown', handleClickOutside);
     window.addEventListener('touchstart', handleClickOutside);
-
     return () => {
       window.removeEventListener('mousedown', handleClickOutside);
       window.removeEventListener('touchstart', handleClickOutside);
@@ -96,13 +79,13 @@ export default function SearchHeader({
         />
         {showRecent && (
           <div
+            id="search-dropdown"
             className="absolute left-0 top-full mt-2 w-full min-w-[180px] max-w-[510px] md:max-w-none bg-white border border-gray-200 rounded-lg shadow-lg p-4 max-h-60 overflow-auto z-[9999]"
             style={{ minHeight: 48 }}>
             {/* 드롭다운 내용 */}
           </div>
         )}
       </div>
-
       <div className="flex gap-2">
         <Button
           leftIcon={<ResetIcon className="transition-transform duration-500 ease-out group-hover:rotate-90" />}

--- a/src/pages/test/_components/searchHeader/SearchHeader.tsx
+++ b/src/pages/test/_components/searchHeader/SearchHeader.tsx
@@ -1,9 +1,10 @@
-import { KeyboardEvent } from 'react';
+import { KeyboardEvent, useRef, useState, useEffect } from 'react';
 import Input from '@/components/ui/input/Input';
 import Select from '@/components/ui/select/Select';
 import Button from '@/components/ui/button/Button';
 import searchIcon from '@/assets/icons/search.svg';
 import ResetIcon from '@/assets/icons/refresh.svg?react';
+import Portal from '@/components/layout/page-layout/Portal'; // Portal 경로에 맞게 import
 
 interface SearchHeaderProps {
   inputValue: string;
@@ -29,6 +30,32 @@ export default function SearchHeader({
   onNameSortChange,
   onDateSortChange
 }: SearchHeaderProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [dropdownPos, setDropdownPos] = useState({ left: 0, top: 0, width: 0 });
+  const [showRecent, setShowRecent] = useState(false);
+
+  function updateDropdownPos() {
+    if (inputRef.current) {
+      const rect = inputRef.current.getBoundingClientRect();
+      setDropdownPos({ left: rect.left, top: rect.bottom, width: rect.width });
+    }
+  }
+
+  const handleInputFocus = () => {
+    updateDropdownPos();
+    setShowRecent(true);
+    // 최근 검색어 불러오기 등 추가 로직
+  };
+
+  useEffect(() => {
+    if (!showRecent) return;
+    updateDropdownPos();
+    window.addEventListener('resize', updateDropdownPos);
+    return () => {
+      window.removeEventListener('resize', updateDropdownPos);
+    };
+  }, [showRecent]);
+
   return (
     <section className="flex items-center justify-between w-full gap-4 pt-5 pb-9">
       <div className="relative flex-1 max-w-[510px] min-w-0">
@@ -39,6 +66,7 @@ export default function SearchHeader({
           onClick={onSearch}
         />
         <Input
+          ref={inputRef}
           type="text"
           placeholder="프로젝트 검색"
           className="w-full max-h-[35px] rounded-20 pl-10 border-[0.5px] border-typography-gray max-md:placeholder:text-[12px]"
@@ -49,7 +77,23 @@ export default function SearchHeader({
               onSearch();
             }
           }}
+          onFocus={handleInputFocus}
         />
+        {showRecent && (
+          <Portal>
+            <div
+              className="fixed z-[9999] bg-white border border-gray-200 rounded-lg shadow-lg p-4 max-h-60 overflow-auto"
+              style={{
+                left: dropdownPos.left,
+                top: dropdownPos.top + 8,
+                width: dropdownPos.width,
+                minWidth: 180,
+                maxWidth: 510 // 필요시 input의 max-width와 맞춤
+              }}>
+              {/* 드롭다운 내용 */}
+            </div>
+          </Portal>
+        )}
       </div>
 
       <div className="flex gap-2">


### PR DESCRIPTION
## 🛰️ Issue Number
이슈번호: #94

## 🪐 작업 내용

<작업 사진>
<img width="490" height="194" alt="image" src="https://github.com/user-attachments/assets/49d00d29-093a-4fe9-871e-678819912726" />


<구현 요약>
제가 지난번에 서치바를 제작할 때 힘들게 만들어 놓으신 statusBadge적용을 안하고 직접 삼항연산자로 구현을 했습니다.
이를 수정했습니다.



<커밋 설명>
사실상 중요한 커밋은 StatusBadge 말고는 도르마무 했습니다.
```                        <StatusBadge status={proj.projectStatus as StatusType} className="ml-2" /
```



```
import { createPortal } from 'react-dom';
import { ReactNode } from 'react';

export default function Portal({ children }: { children: ReactNode }) {
  if (typeof window === 'undefined') return null;
  const el = document.getElementById('portal-root') || document.body;
  return createPortal(children, el);
}
```
-> 이 부분은 서치바 드롭다운을 최상단 레이어로 오게 하기 위해서 Portlas 라는 구조를 사용하면 될 것이라 생각했는데
이게 캐러셀이나 기존에 설정한 input.tsx보다 위로 오게는 성공하였으나 단점이 실시간 페이지 이동에 따라 계산을 해야합니다.

<img width="1140" height="359" alt="image" src="https://github.com/user-attachments/assets/6c71a41c-89d0-4745-83e0-4241a3ff023e" />

이 구글 페이지를 예시로 보면 고정되어있는데 이제 고정되어있지 않게 되는 것이죠

하지만 이를 안쓰고 stacking context요소들을 제거해서 적용하려 하였으나 이미 main content에 적용된 것들을 깨뜨려야해서 돌아가는 길이 되어버린 것이죠

둘 중 어느 방식을 채택해야할지 몰라서 일단 상태뱃지부터 PR올립니다.


## 📚 Reference
https://ko.legacy.reactjs.org/docs/portals.html

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] 코드 스타일을 eslint/prettier로 맞췄나요?