### PR TITLE
[ #104 | Fix ]  refresh

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,10 +9,10 @@ import { ToastContainer } from 'react-toastify';
 import { useEffect, useState } from 'react';
 import ErrorModal from '@/components/modal/ErrorModal';
 import axios from 'axios';
-import { isJwtExpired } from '@/utils/validation';
-import { ROUTES, API_ENDPOINTS } from '@/constants';
-import { RefreshTokenResponse } from '@/types/auth.type';
+import { ROUTES } from '@/constants';
 import TestTokenButton from '@/components/ui/TestTokenButton';
+import { useAppDispatch } from '@/store/redux/store';
+import { logout } from '@/store/redux/reducers/auth';
 
 const queryClient = new QueryClient();
 const router = createBrowserRouter(routes);
@@ -20,40 +20,16 @@ const router = createBrowserRouter(routes);
 function AppWithErrorModal({ children }: { children: React.ReactNode }) {
   const [showErrorModal, setShowErrorModal] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
+  const dispatch = useAppDispatch();
 
-  // JWT 만료 체크 및 리프레시 토큰 시도
+  // Redux 상태와 localStorage 동기화
   useEffect(() => {
-    const checkTokenAndRefresh = async () => {
-      const token = localStorage.getItem('token');
-      if (token && isJwtExpired(token)) {
-        try {
-          // 리프레시 토큰으로 새 액세스 토큰 발급 시도
-          const response = await axios.post<RefreshTokenResponse>(
-            `${import.meta.env.VITE_API_BASE_URL || 'http://219.255.242.174:8080/api/v1'}${API_ENDPOINTS.AUTH.REFRESH}`,
-            {},
-            { withCredentials: true }
-          );
-
-          const newAccessToken = response.data.data?.accessToken;
-          if (newAccessToken) {
-            // 새 토큰 저장
-            localStorage.setItem('token', newAccessToken);
-            console.log('액세스 토큰이 성공적으로 갱신되었습니다.');
-          } else {
-            throw new Error('새 액세스 토큰을 받지 못했습니다.');
-          }
-        } catch (error) {
-          // 리프레시 토큰도 만료되었거나 유효하지 않은 경우
-          console.log('리프레시 토큰 만료 또는 유효하지 않음:', error);
-          setErrorMessage('로그인 세션이 만료되었습니다. 다시 로그인 해주세요.');
-          setShowErrorModal(true);
-          localStorage.removeItem('token');
-        }
-      }
-    };
-
-    checkTokenAndRefresh();
-  }, []);
+    const token = localStorage.getItem('token');
+    if (!token) {
+      // 토큰이 없으면 Redux 상태도 로그아웃 상태로 동기화
+      dispatch(logout());
+    }
+  }, [dispatch]);
 
   // 네트워크 연결 끊김 감지
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,8 +11,7 @@ import ErrorModal from '@/components/modal/ErrorModal';
 import axios from 'axios';
 import { ROUTES } from '@/constants';
 import TestTokenButton from '@/components/ui/TestTokenButton';
-import { useAppDispatch } from '@/store/redux/store';
-import { logout } from '@/store/redux/reducers/auth';
+import { initializeTokenManager } from '@/utils/tokenManager';
 
 const queryClient = new QueryClient();
 const router = createBrowserRouter(routes);
@@ -20,16 +19,11 @@ const router = createBrowserRouter(routes);
 function AppWithErrorModal({ children }: { children: React.ReactNode }) {
   const [showErrorModal, setShowErrorModal] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
-  const dispatch = useAppDispatch();
 
-  // Redux 상태와 localStorage 동기화
+  // 토큰 관리자 초기화
   useEffect(() => {
-    const token = localStorage.getItem('token');
-    if (!token) {
-      // 토큰이 없으면 Redux 상태도 로그아웃 상태로 동기화
-      dispatch(logout());
-    }
-  }, [dispatch]);
+    initializeTokenManager();
+  }, []);
 
   // 네트워크 연결 끊김 감지
   useEffect(() => {
@@ -69,12 +63,8 @@ function AppWithErrorModal({ children }: { children: React.ReactNode }) {
   }, []);
 
   const handleModalRetry = () => {
-    // 만료 에러라면 로그인/랜딩페이지로 이동
-    if (errorMessage.includes('로그인 세션이 만료')) {
-      window.location.href = ROUTES.LANDING;
-    } else {
-      window.location.reload();
-    }
+    // 모든 에러에서 랜딩 페이지로 이동
+    window.location.href = ROUTES.LANDING;
   };
 
   return (

--- a/src/components/layout/page-layout/Layout.tsx
+++ b/src/components/layout/page-layout/Layout.tsx
@@ -2,15 +2,26 @@ import Footer from '@/components/layout/page-layout/Footer';
 import Header from '@/components/layout/page-layout/Header';
 import Sidebar from '@/components/layout/sidebar/Sidebar';
 import { ROUTES } from '@/constants';
-import { useAppSelector } from '@/store/redux/store';
+import { useAppSelector, useAppDispatch } from '@/store/redux/store';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
-import { Suspense, useState } from 'react';
+import { Suspense, useState, useEffect } from 'react';
+import { logout } from '@/store/redux/reducers/auth';
 import PageLoader from '@/components/ui/loader/PageLoader';
 
 export default function Layout() {
   const location = useLocation();
   const { isLoggedIn } = useAppSelector((state) => state.auth);
+  const dispatch = useAppDispatch();
   const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  // Redux 상태와 localStorage 동기화
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token && isLoggedIn) {
+      // 토큰이 없는데 로그인 상태라면 로그아웃 처리
+      dispatch(logout());
+    }
+  }, [dispatch, isLoggedIn]);
 
   // 현재 경로
   const currentPath = location.pathname;

--- a/src/components/modal/RefreshTokenModal.tsx
+++ b/src/components/modal/RefreshTokenModal.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import { API_ENDPOINTS } from '@/constants';
+
+import { toast } from 'react-toastify';
+
+interface RefreshTokenModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  onLogout: () => void;
+}
+
+const RefreshTokenModal: React.FC<RefreshTokenModalProps> = ({ open, onClose, onSuccess, onLogout }) => {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleRefreshToken = async () => {
+    setIsLoading(true);
+    try {
+      // 리프레시 API를 통해 새로운 액세스 토큰 발급
+      const response = await axios.post(
+        `${import.meta.env.VITE_API_BASE_URL || 'http://219.255.242.174:8080/api/v1'}${API_ENDPOINTS.AUTH.REFRESH}`,
+        {},
+        { withCredentials: true }
+      );
+
+      const newAccessToken = response.data.data?.accessToken;
+      if (newAccessToken) {
+        // 새 토큰 저장
+        localStorage.setItem('token', newAccessToken);
+
+        toast.success('토큰이 성공적으로 갱신되었습니다!');
+        onSuccess();
+        onClose();
+      } else {
+        throw new Error('새 액세스 토큰을 받지 못했습니다.');
+      }
+    } catch (error: any) {
+      console.error('토큰 갱신 실패:', error);
+
+      if (error.response?.status === 401) {
+        toast.error('리프레시 토큰이 만료되었습니다. 다시 로그인해주세요.');
+        // 리프레시 토큰도 만료된 경우 로그아웃 처리
+        onLogout();
+      } else {
+        toast.error('토큰 갱신에 실패했습니다. 다시 시도해주세요.');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleLogout = () => {
+    onLogout();
+    onClose();
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg p-6 w-full max-w-md mx-4">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-xl font-semibold text-gray-900">세션 만료</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600" disabled={isLoading}>
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="mb-4">
+          <p className="text-gray-600 mb-4">계속 서비스를 이용하시겠습니까?</p>
+        </div>
+
+        <div className="flex space-x-3 pt-4">
+          <button
+            onClick={handleRefreshToken}
+            disabled={isLoading}
+            className="flex-1 bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed">
+            {isLoading ? '처리중...' : '계속 이용'}
+          </button>
+          <button
+            onClick={handleLogout}
+            disabled={isLoading}
+            className="flex-1 bg-gray-500 text-white py-2 px-4 rounded-md hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-500 disabled:opacity-50 disabled:cursor-not-allowed">
+            로그아웃
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RefreshTokenModal;

--- a/src/components/ui/TestTokenButton.tsx
+++ b/src/components/ui/TestTokenButton.tsx
@@ -252,7 +252,7 @@ const TestTokenButton: React.FC = () => {
         style={{
           margin: '2px',
           padding: '5px',
-          backgroundColor: isLoading ? '#ccc' : '#28a745',
+          backgroundColor: isLoading ? '#ccc' : '#007bff',
           color: 'white',
           border: 'none',
           borderRadius: '3px',
@@ -278,26 +278,11 @@ const TestTokenButton: React.FC = () => {
       </button>
 
       <button
-        onClick={checkTokenInfo}
-        style={{
-          margin: '2px',
-          padding: '5px',
-          backgroundColor: '#17a2b8',
-          color: 'white',
-          border: 'none',
-          borderRadius: '3px',
-          cursor: 'pointer',
-          width: '100%'
-        }}>
-        토큰 정보 확인
-      </button>
-
-      <button
         onClick={setCookieManually}
         style={{
           margin: '2px',
           padding: '5px',
-          backgroundColor: '#007bff',
+          backgroundColor: '#6c757d',
           color: 'white',
           border: 'none',
           borderRadius: '3px',
@@ -308,6 +293,21 @@ const TestTokenButton: React.FC = () => {
       </button>
 
       <hr style={{ margin: '8px 0' }} />
+
+      <button
+        onClick={checkTokenInfo}
+        style={{
+          margin: '2px',
+          padding: '5px',
+          backgroundColor: '#6c757d',
+          color: 'white',
+          border: 'none',
+          borderRadius: '3px',
+          cursor: 'pointer',
+          width: '100%'
+        }}>
+        토큰 정보 확인
+      </button>
 
       <button
         onClick={expireAccessTokenAndRefresh}
@@ -348,8 +348,8 @@ const TestTokenButton: React.FC = () => {
         style={{
           margin: '2px',
           padding: '5px',
-          backgroundColor: '#ffc107',
-          color: 'black',
+          backgroundColor: '#6c757d',
+          color: 'white',
           border: 'none',
           borderRadius: '3px',
           cursor: 'pointer',
@@ -363,7 +363,7 @@ const TestTokenButton: React.FC = () => {
         style={{
           margin: '2px',
           padding: '5px',
-          backgroundColor: '#6f42c1',
+          backgroundColor: '#6c757d',
           color: 'white',
           border: 'none',
           borderRadius: '3px',

--- a/src/components/ui/TestTokenButton.tsx
+++ b/src/components/ui/TestTokenButton.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+const TestTokenButton: React.FC = () => {
+  const expireAccessToken = () => {
+    const token = localStorage.getItem('token');
+    if (token) {
+      const parts = token.split('.');
+      const payload = JSON.parse(atob(parts[1]));
+
+      // exp를 현재 시간보다 1시간 전으로 설정
+      payload.exp = Math.floor(Date.now() / 1000) - 3600;
+
+      const fakeToken = parts[0] + '.' + btoa(JSON.stringify(payload)) + '.' + parts[2];
+      localStorage.setItem('token', fakeToken);
+
+      alert('액세스 토큰이 만료로 설정되었습니다. 페이지를 새로고침하세요.');
+    }
+  };
+
+  const expireRefreshToken = () => {
+    // 리프레시 토큰 쿠키 삭제
+    document.cookie = 'refreshToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+    alert('리프레시 토큰이 삭제되었습니다.');
+  };
+
+  const resetTokens = () => {
+    localStorage.removeItem('token');
+    document.cookie = 'refreshToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+    alert('모든 토큰이 삭제되었습니다.');
+  };
+
+  // 개발 환경에서만 표시
+  if (import.meta.env.PROD) {
+    return null;
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: '10px',
+        right: '10px',
+        zIndex: 9999,
+        background: '#f0f0f0',
+        padding: '10px',
+        border: '1px solid #ccc',
+        borderRadius: '5px'
+      }}>
+      <h4>토큰 테스트 (개발용)</h4>
+      <button onClick={expireAccessToken} style={{ margin: '2px', padding: '5px' }}>
+        액세스 토큰 만료
+      </button>
+      <br />
+      <button onClick={expireRefreshToken} style={{ margin: '2px', padding: '5px' }}>
+        리프레시 토큰 삭제
+      </button>
+      <br />
+      <button onClick={resetTokens} style={{ margin: '2px', padding: '5px' }}>
+        모든 토큰 리셋
+      </button>
+    </div>
+  );
+};
+
+export default TestTokenButton;

--- a/src/components/ui/TestTokenButton.tsx
+++ b/src/components/ui/TestTokenButton.tsx
@@ -1,7 +1,12 @@
-import React from 'react';
+import React, { useState } from 'react';
+import axios from 'axios';
+import { API_ENDPOINTS } from '@/constants';
+import { RefreshTokenResponse } from '@/types/auth.type';
 
 const TestTokenButton: React.FC = () => {
-  const expireAccessToken = () => {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const expireAccessTokenAndRefresh = async () => {
     const token = localStorage.getItem('token');
     if (token) {
       const parts = token.split('.');
@@ -13,7 +18,28 @@ const TestTokenButton: React.FC = () => {
       const fakeToken = parts[0] + '.' + btoa(JSON.stringify(payload)) + '.' + parts[2];
       localStorage.setItem('token', fakeToken);
 
-      alert('액세스 토큰이 만료로 설정되었습니다. 페이지를 새로고침하세요.');
+      // 즉시 리프레시 API 호출
+      setIsLoading(true);
+      try {
+        const response = await axios.post<RefreshTokenResponse>(
+          `${import.meta.env.VITE_API_BASE_URL || 'http://219.255.242.174:8080/api/v1'}${API_ENDPOINTS.AUTH.REFRESH}`,
+          {},
+          { withCredentials: true }
+        );
+
+        const newAccessToken = response.data.data?.accessToken;
+        if (newAccessToken) {
+          localStorage.setItem('token', newAccessToken);
+          alert('✅ 액세스 토큰이 성공적으로 갱신되었습니다!\n새 토큰: ' + newAccessToken.substring(0, 20) + '...');
+        } else {
+          throw new Error('새 액세스 토큰을 받지 못했습니다.');
+        }
+      } catch (error) {
+        console.error('리프레시 토큰 갱신 실패:', error);
+        alert('❌ 리프레시 토큰 갱신에 실패했습니다. 리프레시 토큰이 만료되었거나 유효하지 않습니다.');
+      } finally {
+        setIsLoading(false);
+      }
     }
   };
 
@@ -21,6 +47,37 @@ const TestTokenButton: React.FC = () => {
     // 리프레시 토큰 쿠키 삭제
     document.cookie = 'refreshToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
     alert('리프레시 토큰이 삭제되었습니다.');
+  };
+
+  const testRefreshTokenExpired = async () => {
+    // 먼저 리프레시 토큰 삭제
+    document.cookie = 'refreshToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+
+    // 액세스 토큰 만료 설정
+    const token = localStorage.getItem('token');
+    if (token) {
+      const parts = token.split('.');
+      const payload = JSON.parse(atob(parts[1]));
+      payload.exp = Math.floor(Date.now() / 1000) - 3600;
+      const fakeToken = parts[0] + '.' + btoa(JSON.stringify(payload)) + '.' + parts[2];
+      localStorage.setItem('token', fakeToken);
+
+      // 즉시 리프레시 API 호출 (실패 예상)
+      setIsLoading(true);
+      try {
+        await axios.post<RefreshTokenResponse>(
+          `${import.meta.env.VITE_API_BASE_URL || 'http://219.255.242.174:8080/api/v1'}${API_ENDPOINTS.AUTH.REFRESH}`,
+          {},
+          { withCredentials: true }
+        );
+        alert('❌ 예상과 다르게 성공했습니다.');
+      } catch (error) {
+        console.error('예상된 리프레시 토큰 갱신 실패:', error);
+        alert('✅ 예상대로 리프레시 토큰 갱신에 실패했습니다. 로그아웃 처리됩니다.');
+      } finally {
+        setIsLoading(false);
+      }
+    }
   };
 
   const resetTokens = () => {
@@ -47,12 +104,38 @@ const TestTokenButton: React.FC = () => {
         borderRadius: '5px'
       }}>
       <h4>토큰 테스트 (개발용)</h4>
-      <button onClick={expireAccessToken} style={{ margin: '2px', padding: '5px' }}>
-        액세스 토큰 만료
+      <button
+        onClick={expireAccessTokenAndRefresh}
+        disabled={isLoading}
+        style={{
+          margin: '2px',
+          padding: '5px',
+          backgroundColor: isLoading ? '#ccc' : '#007bff',
+          color: 'white',
+          border: 'none',
+          borderRadius: '3px',
+          cursor: isLoading ? 'not-allowed' : 'pointer'
+        }}>
+        {isLoading ? '처리중...' : '액세스 토큰 만료 + 리프레시'}
+      </button>
+      <br />
+      <button
+        onClick={testRefreshTokenExpired}
+        disabled={isLoading}
+        style={{
+          margin: '2px',
+          padding: '5px',
+          backgroundColor: isLoading ? '#ccc' : '#dc3545',
+          color: 'white',
+          border: 'none',
+          borderRadius: '3px',
+          cursor: isLoading ? 'not-allowed' : 'pointer'
+        }}>
+        {isLoading ? '처리중...' : '리프레시 토큰 만료 테스트'}
       </button>
       <br />
       <button onClick={expireRefreshToken} style={{ margin: '2px', padding: '5px' }}>
-        리프레시 토큰 삭제
+        리프레시 토큰만 삭제
       </button>
       <br />
       <button onClick={resetTokens} style={{ margin: '2px', padding: '5px' }}>

--- a/src/components/ui/TestTokenButton.tsx
+++ b/src/components/ui/TestTokenButton.tsx
@@ -2,44 +2,131 @@ import React, { useState } from 'react';
 import axios from 'axios';
 import { API_ENDPOINTS } from '@/constants';
 import { RefreshTokenResponse } from '@/types/auth.type';
+import {
+  refreshAccessToken,
+  startAutoTokenRefresh,
+  stopAutoTokenRefresh,
+  hasRefreshTokenCookie,
+  getTokenExpiryTime,
+  isTokenExpiringSoon,
+  getAutoRefreshTimer
+} from '@/utils/tokenManager';
 
 const TestTokenButton: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
 
+  // 쿠키 수동 설정 함수 (개발용)
+  const setCookieManually = () => {
+    // 테스트용 리프레시 토큰 쿠키 설정 (Secure 속성 없이)
+    document.cookie =
+      'refreshToken=test-refresh-token-12345; path=/; max-age=604800; SameSite=Lax; domain=219.255.242.174';
+    console.log('수동 쿠키 설정 완료');
+    console.log('설정된 쿠키:', document.cookie);
+    alert('✅ 테스트용 리프레시 토큰 쿠키가 설정되었습니다!\n쿠키: ' + document.cookie);
+  };
+
+  // 쿠키 확인 함수 (개발용)
+  const checkCookies = () => {
+    const cookies = document.cookie;
+    console.log('현재 쿠키:', cookies);
+    console.log('쿠키에 refreshToken 포함 여부:', cookies.includes('refreshToken'));
+    alert(
+      `현재 쿠키:\n${cookies || '쿠키가 없습니다.'}\n\nrefreshToken 포함: ${cookies.includes('refreshToken') ? '예' : '아니오'}`
+    );
+  };
+
+  // 로그인 함수 (리프레시 토큰 쿠키 받기)
+  const loginToGetRefreshToken = async () => {
+    setIsLoading(true);
+    try {
+      console.log('로그인 시작...');
+      console.log('현재 쿠키 (로그인 전):', document.cookie);
+
+      const response = await fetch(
+        `${import.meta.env.VITE_API_BASE_URL || 'http://219.255.242.174:8080/api/v1'}/auth/login`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include', // 중요: 쿠키를 받기 위해 필요
+          body: JSON.stringify({
+            email: 'test@example.com',
+            password: 'testPassword'
+          })
+        }
+      );
+
+      console.log('응답 헤더:', response.headers);
+      console.log('Set-Cookie 헤더:', response.headers.get('set-cookie'));
+
+      const data = await response.json();
+      console.log('로그인 응답:', data);
+
+      if (data.data?.accessToken) {
+        // 액세스 토큰 저장
+        localStorage.setItem('token', data.data.accessToken);
+        console.log('새 액세스 토큰 저장됨:', data.data.accessToken);
+        console.log('localStorage 확인:', localStorage.getItem('token'));
+
+        // 쿠키 확인 (약간의 지연 후)
+        setTimeout(() => {
+          console.log('쿠키 확인 (로그인 후):', document.cookie);
+          alert(
+            `✅ 로그인 성공!\n\n액세스 토큰: ${data.data.accessToken.substring(0, 20)}...\n쿠키: ${document.cookie || '쿠키가 없습니다'}`
+          );
+        }, 100);
+      } else {
+        throw new Error('로그인 실패: ' + (data.message || '알 수 없는 오류'));
+      }
+    } catch (error) {
+      console.error('로그인 실패:', error);
+      alert('❌ 로그인에 실패했습니다.\n' + (error instanceof Error ? error.message : '알 수 없는 오류'));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   const expireAccessTokenAndRefresh = async () => {
     const token = localStorage.getItem('token');
-    if (token) {
-      const parts = token.split('.');
-      const payload = JSON.parse(atob(parts[1]));
+    if (!token) {
+      alert('❌ 액세스 토큰이 없습니다. 먼저 로그인해주세요.');
+      return;
+    }
 
-      // exp를 현재 시간보다 1시간 전으로 설정
-      payload.exp = Math.floor(Date.now() / 1000) - 3600;
+    // 쿠키 확인
+    if (!hasRefreshTokenCookie()) {
+      alert('❌ 리프레시 토큰 쿠키가 없습니다. "쿠키 수동 설정 (개발용)" 버튼을 먼저 클릭해주세요.');
+      return;
+    }
 
-      const fakeToken = parts[0] + '.' + btoa(JSON.stringify(payload)) + '.' + parts[2];
-      localStorage.setItem('token', fakeToken);
+    const parts = token.split('.');
+    const payload = JSON.parse(atob(parts[1]));
 
-      // 즉시 리프레시 API 호출
-      setIsLoading(true);
-      try {
-        const response = await axios.post<RefreshTokenResponse>(
-          `${import.meta.env.VITE_API_BASE_URL || 'http://219.255.242.174:8080/api/v1'}${API_ENDPOINTS.AUTH.REFRESH}`,
-          {},
-          { withCredentials: true }
-        );
+    // exp를 현재 시간보다 1시간 전으로 설정
+    payload.exp = Math.floor(Date.now() / 1000) - 3600;
 
-        const newAccessToken = response.data.data?.accessToken;
-        if (newAccessToken) {
-          localStorage.setItem('token', newAccessToken);
-          alert('✅ 액세스 토큰이 성공적으로 갱신되었습니다!\n새 토큰: ' + newAccessToken.substring(0, 20) + '...');
-        } else {
-          throw new Error('새 액세스 토큰을 받지 못했습니다.');
-        }
-      } catch (error) {
-        console.error('리프레시 토큰 갱신 실패:', error);
-        alert('❌ 리프레시 토큰 갱신에 실패했습니다. 리프레시 토큰이 만료되었거나 유효하지 않습니다.');
-      } finally {
-        setIsLoading(false);
+    const fakeToken = parts[0] + '.' + btoa(JSON.stringify(payload)) + '.' + parts[2];
+    localStorage.setItem('token', fakeToken);
+    console.log('액세스 토큰 만료 설정 완료');
+
+    // 즉시 토큰 재발급 시도
+    setIsLoading(true);
+    try {
+      console.log('토큰 재발급 테스트 시작...');
+      const newAccessToken = await refreshAccessToken();
+
+      if (newAccessToken) {
+        console.log('새 액세스 토큰 저장됨:', newAccessToken);
+        alert('✅ 액세스 토큰이 성공적으로 갱신되었습니다!\n새 토큰: ' + newAccessToken.substring(0, 20) + '...');
+      } else {
+        throw new Error('새 액세스 토큰을 받지 못했습니다.');
       }
+    } catch (error: any) {
+      console.error('토큰 재발급 실패:', error);
+      alert(
+        `❌ 토큰 재발급에 실패했습니다.\n\n에러: ${error.response?.data?.message || error.message}\n\n해결방법: "쿠키 수동 설정 (개발용)" 버튼을 클릭한 후 다시 시도해주세요.`
+      );
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -73,7 +160,9 @@ const TestTokenButton: React.FC = () => {
         alert('❌ 예상과 다르게 성공했습니다.');
       } catch (error) {
         console.error('예상된 리프레시 토큰 갱신 실패:', error);
-        alert('✅ 예상대로 리프레시 토큰 갱신에 실패했습니다. 로그아웃 처리됩니다.');
+        alert('✅ 예상대로 리프레시 토큰 갱신에 실패했습니다. 자동 재시도 후 로그아웃 처리됩니다.');
+        // 자동으로 랜딩 페이지로 이동
+        window.location.href = '/landing';
       } finally {
         setIsLoading(false);
       }
@@ -86,8 +175,58 @@ const TestTokenButton: React.FC = () => {
     alert('모든 토큰이 삭제되었습니다.');
   };
 
-  // 개발 환경에서만 표시
-  if (import.meta.env.PROD) {
+  // 토큰 정보 확인
+  const checkTokenInfo = () => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      alert('토큰이 없습니다.');
+      return;
+    }
+
+    try {
+      // JWT 토큰 디코딩
+      const parts = token.split('.');
+      const payload = JSON.parse(atob(parts[1]));
+
+      const expiryTime = getTokenExpiryTime(token);
+      const isExpiringSoon = isTokenExpiringSoon(token);
+      const hasCookie = hasRefreshTokenCookie();
+
+      const expiryDate = expiryTime ? new Date(expiryTime).toLocaleString() : '알 수 없음';
+      const timeLeft = expiryTime ? Math.max(0, Math.floor((expiryTime - Date.now()) / 1000 / 60)) : 0;
+
+      // 토큰 발급 시간 계산
+      const issuedAt = payload.iat ? new Date(payload.iat * 1000).toLocaleString() : '알 수 없음';
+      const tokenDuration = payload.exp && payload.iat ? Math.floor((payload.exp - payload.iat) / 60) : 0;
+
+      alert(
+        `토큰 정보:\n\n` +
+          `발급 시간: ${issuedAt}\n` +
+          `만료 시간: ${expiryDate}\n` +
+          `토큰 유효 기간: ${tokenDuration}분\n` +
+          `남은 시간: ${timeLeft}분\n` +
+          `곧 만료: ${isExpiringSoon ? '예' : '아니오'}\n` +
+          `리프레시 쿠키: ${hasCookie ? '있음' : '없음'}\n\n` +
+          `서버 설정 토큰 만료 시간: ${tokenDuration}분`
+      );
+    } catch (error) {
+      alert('토큰 파싱에 실패했습니다: ' + error);
+    }
+  };
+
+  // 자동 토큰 재발급 시작/중지
+  const toggleAutoRefresh = () => {
+    if (getAutoRefreshTimer()) {
+      stopAutoTokenRefresh();
+      alert('자동 토큰 재발급이 중지되었습니다.');
+    } else {
+      startAutoTokenRefresh();
+      alert('자동 토큰 재발급이 시작되었습니다. (1시간 간격)');
+    }
+  };
+
+  // 개발 환경에서만 표시 (배포 환경에서는 완전히 제거)
+  if (import.meta.env.PROD || import.meta.env.NODE_ENV === 'production') {
     return null;
   }
 
@@ -101,9 +240,75 @@ const TestTokenButton: React.FC = () => {
         background: '#f0f0f0',
         padding: '10px',
         border: '1px solid #ccc',
-        borderRadius: '5px'
+        borderRadius: '5px',
+        maxWidth: '300px'
       }}>
       <h4>토큰 테스트 (개발용)</h4>
+
+      {/* 로그인 버튼 추가 */}
+      <button
+        onClick={loginToGetRefreshToken}
+        disabled={isLoading}
+        style={{
+          margin: '2px',
+          padding: '5px',
+          backgroundColor: isLoading ? '#ccc' : '#28a745',
+          color: 'white',
+          border: 'none',
+          borderRadius: '3px',
+          cursor: isLoading ? 'not-allowed' : 'pointer',
+          width: '100%'
+        }}>
+        {isLoading ? '로그인 중...' : '로그인 (리프레시 토큰 받기)'}
+      </button>
+
+      <button
+        onClick={checkCookies}
+        style={{
+          margin: '2px',
+          padding: '5px',
+          backgroundColor: '#6c757d',
+          color: 'white',
+          border: 'none',
+          borderRadius: '3px',
+          cursor: 'pointer',
+          width: '100%'
+        }}>
+        쿠키 확인
+      </button>
+
+      <button
+        onClick={checkTokenInfo}
+        style={{
+          margin: '2px',
+          padding: '5px',
+          backgroundColor: '#17a2b8',
+          color: 'white',
+          border: 'none',
+          borderRadius: '3px',
+          cursor: 'pointer',
+          width: '100%'
+        }}>
+        토큰 정보 확인
+      </button>
+
+      <button
+        onClick={setCookieManually}
+        style={{
+          margin: '2px',
+          padding: '5px',
+          backgroundColor: '#007bff',
+          color: 'white',
+          border: 'none',
+          borderRadius: '3px',
+          cursor: 'pointer',
+          width: '100%'
+        }}>
+        쿠키 수동 설정 (개발용)
+      </button>
+
+      <hr style={{ margin: '8px 0' }} />
+
       <button
         onClick={expireAccessTokenAndRefresh}
         disabled={isLoading}
@@ -114,11 +319,12 @@ const TestTokenButton: React.FC = () => {
           color: 'white',
           border: 'none',
           borderRadius: '3px',
-          cursor: isLoading ? 'not-allowed' : 'pointer'
+          cursor: isLoading ? 'not-allowed' : 'pointer',
+          width: '100%'
         }}>
         {isLoading ? '처리중...' : '액세스 토큰 만료 + 리프레시'}
       </button>
-      <br />
+
       <button
         onClick={testRefreshTokenExpired}
         disabled={isLoading}
@@ -129,17 +335,59 @@ const TestTokenButton: React.FC = () => {
           color: 'white',
           border: 'none',
           borderRadius: '3px',
-          cursor: isLoading ? 'not-allowed' : 'pointer'
+          cursor: isLoading ? 'not-allowed' : 'pointer',
+          width: '100%'
         }}>
         {isLoading ? '처리중...' : '리프레시 토큰 만료 테스트'}
       </button>
-      <br />
-      <button onClick={expireRefreshToken} style={{ margin: '2px', padding: '5px' }}>
+
+      <hr style={{ margin: '8px 0' }} />
+
+      <button
+        onClick={expireRefreshToken}
+        style={{
+          margin: '2px',
+          padding: '5px',
+          backgroundColor: '#ffc107',
+          color: 'black',
+          border: 'none',
+          borderRadius: '3px',
+          cursor: 'pointer',
+          width: '100%'
+        }}>
         리프레시 토큰만 삭제
       </button>
-      <br />
-      <button onClick={resetTokens} style={{ margin: '2px', padding: '5px' }}>
+
+      <button
+        onClick={resetTokens}
+        style={{
+          margin: '2px',
+          padding: '5px',
+          backgroundColor: '#6f42c1',
+          color: 'white',
+          border: 'none',
+          borderRadius: '3px',
+          cursor: 'pointer',
+          width: '100%'
+        }}>
         모든 토큰 리셋
+      </button>
+
+      <hr style={{ margin: '8px 0' }} />
+
+      <button
+        onClick={toggleAutoRefresh}
+        style={{
+          margin: '2px',
+          padding: '5px',
+          backgroundColor: getAutoRefreshTimer() ? '#dc3545' : '#28a745',
+          color: 'white',
+          border: 'none',
+          borderRadius: '3px',
+          cursor: 'pointer',
+          width: '100%'
+        }}>
+        {getAutoRefreshTimer() ? '자동 재발급 중지' : '자동 재발급 시작'}
       </button>
     </div>
   );

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -6,6 +6,7 @@ import { ROUTES } from '@/constants';
 import { useAppDispatch } from '@/store/redux/store';
 import { setToken } from '@/store/redux/reducers/auth';
 import { toast } from 'react-toastify';
+import { initializeTokenManager } from '@/utils/tokenManager';
 
 export default function LoginPage() {
   const navigate = useNavigate();
@@ -19,6 +20,9 @@ export default function LoginPage() {
         if (response.data && response.data.accessToken) {
           dispatch(setToken(response.data.accessToken));
         }
+
+        // 토큰 관리자 초기화 (자동 재발급 시작)
+        initializeTokenManager();
 
         toast.success(response.message);
         navigate(ROUTES.HOME);

--- a/src/services/api/axios.ts
+++ b/src/services/api/axios.ts
@@ -1,9 +1,9 @@
 import axios from 'axios';
-import { API_ENDPOINTS, ROUTES } from '@/constants';
+import { ROUTES } from '@/constants';
 import { store } from '@/store/redux/store';
-import { logout, setToken } from '@/store/redux/reducers/auth';
+import { logout } from '@/store/redux/reducers/auth';
 import { toast } from 'react-toastify';
-import { RefreshTokenResponse, RefreshTokenErrorResponse } from '@/types/auth.type';
+import { refreshAccessToken, handleTokenExpiration, hasRefreshTokenCookie } from '@/utils/tokenManager';
 
 // refresh 재요청 queue에 들어갈 요청 형태 정의
 type FailQueueItem = {
@@ -11,7 +11,7 @@ type FailQueueItem = {
   reject: (error: unknown) => void;
 };
 
-const baseURL = import.meta.env.VITE_API_BASE_URL || 'http://219.255.242.174:8080/api/v1';
+const baseURL = import.meta.env.VITE_API_BASE_URL || 'https://api.auta.com/api/v1';
 
 const axiosInstance = axios.create({
   baseURL,
@@ -77,57 +77,34 @@ axiosInstance.interceptors.response.use(
       isRefreshing = true; // 토큰 refresh 시작
 
       try {
-        const response = await axiosInstance.post<RefreshTokenResponse>(
-          API_ENDPOINTS.AUTH.REFRESH,
-          {},
-          { withCredentials: true }
-        );
-
-        // 응답에서 새 access token 확인
-        const newAccessToken = response.data.data?.accessToken;
-        if (!newAccessToken) {
-          throw new Error('accessToken이 응답에 없습니다.');
+        // 리프레시 토큰 쿠키 확인
+        if (!hasRefreshTokenCookie()) {
+          if (import.meta.env.DEV) {
+            console.log('리프레시 토큰 쿠키가 없습니다.');
+          }
+          handleTokenExpiration();
+          return Promise.reject(new Error('Refresh Token 쿠키가 없습니다.'));
         }
 
-        // 새 토큰 저장 & 상태 업데이트
-        localStorage.setItem('token', newAccessToken);
-        store.dispatch(setToken(newAccessToken)); // redux 상태 갱신
-        processQueue(null, newAccessToken); // 대기 중인 다른 요청들 처리
+        // 토큰 재발급 시도
+        const newAccessToken = await refreshAccessToken();
+        if (!newAccessToken) {
+          throw new Error('토큰 재발급에 실패했습니다.');
+        }
 
+        processQueue(null, newAccessToken); // 대기 중인 다른 요청들 처리
         originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
         return axiosInstance(originalRequest);
-      } catch (refreshError) {
-        // 에러 타입별 처리
-        if (refreshError.response) {
-          // 서버에서 응답이 온 경우 (4xx, 5xx 에러)
-          const { status, data } = refreshError.response;
+      } catch (refreshError: any) {
+        // 에러 처리
+        if (import.meta.env.DEV) {
+          console.error('토큰 재발급 실패:', refreshError);
+        }
+        processQueue(refreshError, null);
 
-          if (status === 401) {
-            // 리프레시 토큰이 유효하지 않은 경우 - 로그아웃 처리
-            const errorData = data as RefreshTokenErrorResponse;
-            console.log('리프레시 토큰 만료:', errorData.message);
-
-            processQueue(refreshError, null);
-            store.dispatch(logout());
-            toast.error('세션이 만료되었습니다. 다시 로그인해주세요.');
-            window.location.href = ROUTES.LOGIN;
-          } else if (status >= 500) {
-            // 서버 오류 - 재시도하지 않고 원래 요청 실패 처리
-            console.log('서버 오류로 인한 리프레시 토큰 요청 실패:', status);
-            processQueue(refreshError, null);
-          } else {
-            // 기타 4xx 에러 - 재시도하지 않고 원래 요청 실패 처리
-            console.log('리프레시 토큰 요청 실패:', status, data);
-            processQueue(refreshError, null);
-          }
-        } else if (refreshError.request) {
-          // 네트워크 오류 - 재시도하지 않고 원래 요청 실패 처리
-          console.log('네트워크 오류로 인한 리프레시 토큰 요청 실패');
-          processQueue(refreshError, null);
-        } else {
-          // 기타 오류 (토큰이 없는 경우 등) - 재시도하지 않고 원래 요청 실패 처리
-          console.log('리프레시 토큰 요청 중 기타 오류:', refreshError.message);
-          processQueue(refreshError, null);
+        // 리프레시 토큰이 만료된 경우 로그아웃 처리
+        if (refreshError.response?.status === 401) {
+          handleTokenExpiration();
         }
 
         return Promise.reject(refreshError);
@@ -138,9 +115,10 @@ axiosInstance.interceptors.response.use(
 
     // 403(권한 부족) 에러도 강제 로그아웃 처리 (이건 혹시나 해서...)
     if (error.response?.status === 403) {
+      localStorage.removeItem('token'); // localStorage에서 토큰 삭제
       store.dispatch(logout());
       toast.error('접근 권한이 없습니다. 다시 로그인해주세요.');
-      window.location.href = ROUTES.LOGIN;
+      window.location.href = ROUTES.LANDING;
       return Promise.reject(error);
     }
 

--- a/src/store/queries/auth/useAuthMutations.ts
+++ b/src/store/queries/auth/useAuthMutations.ts
@@ -2,6 +2,7 @@ import { API_ENDPOINTS } from '@/constants';
 import axiosInstance from '@/services/api/axios';
 import { LoginRequest, LoginResponse, SignupRequest } from '@/types/auth.type';
 import { useMutation } from '@tanstack/react-query';
+import { cleanupTokenManager } from '@/utils/tokenManager';
 
 export const useSignup = () => {
   return useMutation({
@@ -27,6 +28,8 @@ export const useLogout = () => {
   return useMutation({
     mutationFn: async () => {
       await axiosInstance.post(API_ENDPOINTS.AUTH.LOGOUT);
+      // 토큰 관리자 정리
+      cleanupTokenManager();
     }
   });
 };

--- a/src/types/auth.type.ts
+++ b/src/types/auth.type.ts
@@ -34,3 +34,20 @@ export interface AuthState {
 export interface RefreshTokenResponseData {
   accessToken: string;
 }
+
+// 토큰 재발급 응답 타입
+export interface RefreshTokenResponse {
+  status: string;
+  message: string;
+  data: {
+    accessToken: string;
+  };
+  code: number;
+}
+
+// 토큰 재발급 에러 응답 타입
+export interface RefreshTokenErrorResponse {
+  status: string;
+  message: string;
+  code: number;
+}

--- a/src/utils/tokenManager.ts
+++ b/src/utils/tokenManager.ts
@@ -1,0 +1,191 @@
+import axiosInstance from '@/services/api/axios';
+import { API_ENDPOINTS } from '@/constants';
+import { store } from '@/store/redux/store';
+import { setToken, logout } from '@/store/redux/reducers/auth';
+import { toast } from 'react-toastify';
+import { RefreshTokenResponse } from '@/types/auth.type';
+
+// 토큰 만료 시간 (1시간 = 3600초)
+const TOKEN_EXPIRY_TIME = 60 * 60 * 1000; // 1시간을 밀리초로
+
+// 자동 토큰 재발급 타이머
+let autoRefreshTimer: NodeJS.Timeout | null = null;
+
+// 타이머 상태 확인을 위한 export
+export const getAutoRefreshTimer = () => autoRefreshTimer;
+
+/**
+ * JWT 토큰에서 만료 시간을 추출하는 함수
+ */
+export const getTokenExpiryTime = (token: string): number | null => {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+
+    const payload = JSON.parse(atob(parts[1]));
+    return payload.exp * 1000; // 초를 밀리초로 변환
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.error('토큰 파싱 오류:', error);
+    }
+    return null;
+  }
+};
+
+/**
+ * 토큰이 만료되었는지 확인하는 함수
+ */
+export const isTokenExpired = (token: string): boolean => {
+  const expiryTime = getTokenExpiryTime(token);
+  if (!expiryTime) return true;
+
+  return Date.now() >= expiryTime;
+};
+
+/**
+ * 토큰이 곧 만료될 예정인지 확인하는 함수 (5분 전)
+ */
+export const isTokenExpiringSoon = (token: string): boolean => {
+  const expiryTime = getTokenExpiryTime(token);
+  if (!expiryTime) return true;
+
+  const fiveMinutes = 5 * 60 * 1000; // 5분을 밀리초로
+  return Date.now() >= expiryTime - fiveMinutes;
+};
+
+/**
+ * 리프레시 토큰 쿠키가 존재하는지 확인하는 함수
+ */
+export const hasRefreshTokenCookie = (): boolean => {
+  return document.cookie.includes('refreshToken=');
+};
+
+/**
+ * 토큰 재발급 함수
+ */
+export const refreshAccessToken = async (): Promise<string | null> => {
+  try {
+    // 리프레시 토큰 쿠키 확인
+    if (!hasRefreshTokenCookie()) {
+      if (import.meta.env.DEV) {
+        console.log('리프레시 토큰 쿠키가 없습니다.');
+      }
+      return null;
+    }
+
+    const response = await axiosInstance.post<RefreshTokenResponse>(
+      API_ENDPOINTS.AUTH.REFRESH,
+      {},
+      { withCredentials: true }
+    );
+
+    const newAccessToken = response.data.data?.accessToken;
+    if (!newAccessToken) {
+      throw new Error('새 액세스 토큰을 받지 못했습니다.');
+    }
+
+    // 새 토큰 저장
+    localStorage.setItem('token', newAccessToken);
+    store.dispatch(setToken(newAccessToken));
+
+    if (import.meta.env.DEV) {
+      console.log('토큰 재발급 성공:', new Date().toLocaleString());
+    }
+    return newAccessToken;
+  } catch (error: any) {
+    if (import.meta.env.DEV) {
+      console.error('토큰 재발급 실패:', error);
+    }
+
+    if (error.response?.status === 401) {
+      // 리프레시 토큰이 만료된 경우
+      if (import.meta.env.DEV) {
+        console.log('리프레시 토큰이 만료되었습니다.');
+      }
+      handleTokenExpiration();
+    }
+
+    return null;
+  }
+};
+
+/**
+ * 토큰 만료 시 처리 함수
+ */
+export const handleTokenExpiration = () => {
+  localStorage.removeItem('token');
+  store.dispatch(logout());
+  toast.error('세션이 만료되었습니다. 다시 로그인해주세요.');
+  window.location.href = '/landing';
+};
+
+/**
+ * 자동 토큰 재발급 타이머 설정
+ */
+export const startAutoTokenRefresh = () => {
+  // 기존 타이머가 있다면 제거
+  stopAutoTokenRefresh();
+
+  // 1시간마다 토큰 재발급
+  autoRefreshTimer = setInterval(async () => {
+    const currentToken = localStorage.getItem('token');
+
+    if (currentToken && hasRefreshTokenCookie()) {
+      console.log('자동 토큰 재발급 시작:', new Date().toLocaleString());
+      await refreshAccessToken();
+    } else {
+      if (import.meta.env.DEV) {
+        console.log('토큰이 없거나 리프레시 토큰 쿠키가 없어 자동 재발급을 건너뜁니다.');
+      }
+    }
+  }, TOKEN_EXPIRY_TIME);
+
+  if (import.meta.env.DEV) {
+    console.log('자동 토큰 재발급 타이머가 시작되었습니다. (1시간 간격)');
+  }
+};
+
+/**
+ * 자동 토큰 재발급 타이머 중지
+ */
+export const stopAutoTokenRefresh = () => {
+  if (autoRefreshTimer) {
+    clearInterval(autoRefreshTimer);
+    autoRefreshTimer = null;
+    if (import.meta.env.DEV) {
+      console.log('자동 토큰 재발급 타이머가 중지되었습니다.');
+    }
+  }
+};
+
+/**
+ * 토큰 상태 초기화 및 자동 재발급 시작
+ */
+export const initializeTokenManager = () => {
+  const currentToken = localStorage.getItem('token');
+
+  if (currentToken && hasRefreshTokenCookie()) {
+    // 토큰이 있고 쿠키도 있으면 자동 재발급 시작
+    startAutoTokenRefresh();
+
+    // 토큰이 곧 만료될 예정이면 즉시 재발급
+    if (isTokenExpiringSoon(currentToken)) {
+      if (import.meta.env.DEV) {
+        console.log('토큰이 곧 만료될 예정입니다. 즉시 재발급합니다.');
+      }
+      refreshAccessToken();
+    }
+  } else {
+    if (import.meta.env.DEV) {
+      console.log('토큰이나 리프레시 토큰이 없어 자동 재발급을 시작하지 않습니다.');
+    }
+  }
+};
+
+/**
+ * 로그아웃 시 토큰 관리 정리
+ */
+export const cleanupTokenManager = () => {
+  stopAutoTokenRefresh();
+  localStorage.removeItem('token');
+};


### PR DESCRIPTION
## 🛰️ Issue Number
이슈번호: #104

## 🪐 작업 내용

<작업 사진>
<img width="1348" height="644" alt="image" src="https://github.com/user-attachments/assets/e9d99776-03d3-426a-aec9-03814494cd1c" />


<구현 요약>
개발 환경 강제로 쿠키 발급은 https 에서만 되는 것 같아서 임의로 리프레시 토큰 쿠키에다가 생성해서 확인해보려했으나 안되어서 일단 배포를 하고 확인해보는 절차를 가져보려합니다.

- 2시간 마다 리프레시 토큰 /auth/reissue 를 통해 재발급
- 토큰의 만료시간을 강제로 뒤로 밀어서 그 상황에서는 재로그인을 위해 랜딩페이지로 이동하는 것 확인

<커밋 설명>



## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] 코드 스타일을 eslint/prettier로 맞췄나요?