### PR TITLE
[ #114 | Fix ] 테스트 세부 페이지 카테고리 초기화 오류 수정

### DIFF
--- a/src/pages/test/_components/testDetail/page-issue/index.tsx
+++ b/src/pages/test/_components/testDetail/page-issue/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import type { TestDetail } from '@/types/test.type';
 import { useGetPageIssue } from '@/store/queries/test/useTestQueries';
@@ -31,6 +31,28 @@ export default function PageIssueSection({ testDetail }: PageIssueSectionProps) 
   const { data: issueData, isLoading: isPending, isError } = useGetPageIssue(pageId);
 
   const { issueCounts, tabMeta } = useIssueData(issueData || {}, filters);
+
+  /** category 오류 수정 부분
+   * 페이지 변경할 때, 선택된 이슈가 상태로 저장되는데 그게 그대로 넘어가서 다음 페이지에 갔을 때 그 이슈 인덱스가 없을 때 오류가 발생하는 것 같습니다.
+   * 그래서 페이지 변경될 때마다 선택된 이슈 인덱스를 0으로 초기화 해줬어요
+   */
+  useEffect(() => {
+    setSelectedIssueIndex(0);
+  }, [pageId]);
+
+  /** 전체 선택 시, 이슈가 없는 건 선택 안되게 수정한 부분
+   * 페이지 데이터 불러오면 이슈 개수에 따라 필터 초기화시키기
+   * 이슈가 0인 테스트는 체크 해제 상태로 시작
+   */
+  useEffect(() => {
+    if (issueData) {
+      setFilters({
+        routing: issueCounts.routing > 0,
+        interaction: issueCounts.interaction > 0,
+        mapping: issueCounts.mapping > 0
+      });
+    }
+  }, [pageId, issueData]);
 
   if (isPending) {
     return <PageLoader />;

--- a/src/store/queries/test/useTestQueries.ts
+++ b/src/store/queries/test/useTestQueries.ts
@@ -45,6 +45,8 @@ export const useGetPageIssue = (pageId: number) => {
 
       return response.data.data;
     },
-    enabled: !!pageId
+    enabled: !!pageId,
+    refetchOnMount: true, // 컴포넌트 마운트 시 항상 새로 fetch
+    gcTime: 0 // 캐시 저장하지 않음
   });
 };


### PR DESCRIPTION
## 🛰️ Issue Number
이슈번호: #114

## 🪐 작업 내용

<작업 사진>
**1) 문제**: 현재 페이지에서 선택된 이슈 인덱스가 다른 페이지로 넘어갈 경우에, 그 페이지에 해당 인덱스가 없으면 null/undifined 런타임 에러 발생
<img width="1103" height="265" alt="image" src="https://github.com/user-attachments/assets/7802a1ba-bc2e-4a38-b728-a676fc15e663" />

-  **첫 번째 해결 시도**: `useEffect`를 이용해서 `pageId`가 바뀔 때마다 현재 선택된 이슈 인덱스(`selectedIssueIndex`)가 0이 되도록 수정
→ 처음 만나는 페이지는 오류가 발생하지 않으나, 다시 접근할 경우 똑같은 오류 발생
<img width="902" height="122" alt="image" src="https://github.com/user-attachments/assets/c6722bc5-ba26-4497-9f47-bf44caf0c5f3" />
<img width="809" height="221" alt="image" src="https://github.com/user-attachments/assets/a7dfad11-c6e4-4d65-a101-de9ef302601e" />
   

-  **두 번째 해결 시도**: 페이지 이슈들을 불러오는 api를 호출할 때 TanStack Query를 쓰고 있기 때문에 캐싱 기능이 자동으로 쓰이고 있다고 판단하여 gcTime: 0으로 설정하여 캐싱을 하지 않도록 설정
→ 여러 번 반복해도 오류 발생하지 않음. 해결
<img width="809" height="221" alt="image" src="https://github.com/user-attachments/assets/60abed68-d53c-4f42-a8fe-0ada4241bd25" />

   

**2) 그 외**: 모든 페이지에서 전체 테스트에 대해 전체 선택 필터링을 걸어놓았는데 조금 어색하다고 판단, useEffect로 페이지가 변경될 때마다 이슈 개수가 0 초과인 것만 선택된 상태로 보여지도록 수정
<img width="423" height="210" alt="image" src="https://github.com/user-attachments/assets/167ba454-3dc1-4048-9ded-011dd846b53d" />
<img width="688" height="406" alt="image" src="https://github.com/user-attachments/assets/5d1a3e39-62f4-434d-b55d-8dce80cf6ae4" />

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
- [x] 코드 스타일을 eslint/prettier로 맞췄나요?